### PR TITLE
Fix recon settings test.

### DIFF
--- a/src/hockeypuck/conflux/recon/settings_test.go
+++ b/src/hockeypuck/conflux/recon/settings_test.go
@@ -127,10 +127,10 @@ reconAddr="flarb"
 httpNet="tcp"
 httpAddr="1.2.3.4:8080"
 reconNet="tcp"
-reconAddr=":nope"
+reconAddr=":-1"
 `,
 		nil,
-		`.*unknown port.*`,
+		`.*invalid port.*`,
 	}, {
 		"new-style recon partners",
 		`


### PR DESCRIPTION
Invalid port 'nope' seems to trigger a different error message in Go
1.12 on linux. Updated to use a numeric invalid port.