### PR TITLE
HKP query policy configuration options to protect gnupg.

### DIFF
--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -265,7 +265,9 @@ func (h *Handler) keys(l *Lookup) ([]*openpgp.PrimaryKey, error) {
 	}
 	if h.selfSignedOnly {
 		for _, key := range keys {
-			openpgp.SelfSignedOnly(key)
+			if err := openpgp.SelfSignedOnly(key); err != nil {
+				return nil, errgo.Mask(err)
+			}
 		}
 	}
 	return keys, nil

--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -45,6 +45,8 @@ const (
 	fingerprintKeyIDLen = 40
 )
 
+var errKeywordSearchNotAvailable = errgo.New("keyword search is not available")
+
 func httpError(w http.ResponseWriter, statusCode int, err error) {
 	if statusCode != http.StatusNotFound {
 		log.Errorf("HTTP %d: %v", statusCode, errgo.Details(err))
@@ -60,6 +62,9 @@ type Handler struct {
 
 	statsTemplate *template.Template
 	statsFunc     func() (interface{}, error)
+
+	selfSignedOnly  bool
+	fingerprintOnly bool
 }
 
 type HandlerOption func(h *Handler) error
@@ -116,6 +121,20 @@ func StatsTemplate(path string, extra ...string) HandlerOption {
 func StatsFunc(f func() (interface{}, error)) HandlerOption {
 	return func(h *Handler) error {
 		h.statsFunc = f
+		return nil
+	}
+}
+
+func SelfSignedOnly(selfSignedOnly bool) HandlerOption {
+	return func(h *Handler) error {
+		h.selfSignedOnly = selfSignedOnly
+		return nil
+	}
+}
+
+func FingerprintOnly(fingerprintOnly bool) HandlerOption {
+	return func(h *Handler) error {
+		h.fingerprintOnly = fingerprintOnly
 		return nil
 	}
 }
@@ -229,6 +248,9 @@ func (h *Handler) resolve(l *Lookup) ([]string, error) {
 			return h.storage.Resolve([]string{keyID})
 		}
 	}
+	if h.fingerprintOnly {
+		return nil, errKeywordSearchNotAvailable
+	}
 	return h.storage.MatchKeyword([]string{l.Search})
 }
 
@@ -237,12 +259,24 @@ func (h *Handler) keys(l *Lookup) ([]*openpgp.PrimaryKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return h.storage.FetchKeys(rfps)
+	keys, err := h.storage.FetchKeys(rfps)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	if h.selfSignedOnly {
+		for _, key := range keys {
+			openpgp.SelfSignedOnly(key)
+		}
+	}
+	return keys, nil
 }
 
 func (h *Handler) get(w http.ResponseWriter, l *Lookup) {
 	keys, err := h.keys(l)
-	if err != nil {
+	if err == errKeywordSearchNotAvailable {
+		httpError(w, http.StatusBadRequest, errgo.Mask(err))
+		return
+	} else if err != nil {
 		httpError(w, http.StatusInternalServerError, errgo.Mask(err))
 		return
 	}

--- a/src/hockeypuck/openpgp/resolve.go
+++ b/src/hockeypuck/openpgp/resolve.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-func SelfSignedOnly(key *PrimaryKey) {
+func SelfSignedOnly(key *PrimaryKey) error {
 	var userIDs []*UserID
 	var userAttributes []*UserAttribute
 	var subKeys []*SubKey
@@ -75,6 +75,7 @@ func SelfSignedOnly(key *PrimaryKey) {
 	key.UserIDs = userIDs
 	key.UserAttributes = userAttributes
 	key.SubKeys = subKeys
+	return key.updateMD5()
 }
 
 func DropDuplicates(key *PrimaryKey) error {

--- a/src/hockeypuck/openpgp/resolve.go
+++ b/src/hockeypuck/openpgp/resolve.go
@@ -24,6 +24,59 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
+func SelfSignedOnly(key *PrimaryKey) {
+	var userIDs []*UserID
+	var userAttributes []*UserAttribute
+	var subKeys []*SubKey
+	for _, uid := range key.UserIDs {
+		ss := uid.SelfSigs(key)
+		var certs []*Signature
+		for _, cert := range ss.Certifications {
+			if cert.Error == nil {
+				certs = append(certs, cert.Signature)
+			}
+		}
+		if len(certs) > 0 {
+			uid.Signatures = certs
+			userIDs = append(userIDs, uid)
+		}
+	}
+	for _, uat := range key.UserAttributes {
+		ss := uat.SelfSigs(key)
+		var certs []*Signature
+		for _, cert := range ss.Certifications {
+			if cert.Error == nil {
+				certs = append(certs, cert.Signature)
+			}
+		}
+		if len(certs) > 0 {
+			uat.Signatures = certs
+			userAttributes = append(userAttributes, uat)
+		}
+	}
+	for _, subKey := range key.SubKeys {
+		ss := subKey.SelfSigs(key)
+		var certs []*Signature
+		for _, cert := range ss.Revocations {
+			if cert.Error == nil {
+				certs = append(certs, cert.Signature)
+			}
+		}
+		for _, cert := range ss.Certifications {
+			if cert.Error == nil {
+				certs = append(certs, cert.Signature)
+			}
+		}
+		if len(certs) > 0 {
+			subKey.Signatures = certs
+			subKeys = append(subKeys, subKey)
+		}
+	}
+	key.UserIDs = userIDs
+	key.UserAttributes = userAttributes
+	key.SubKeys = subKeys
+}
+
 func DropDuplicates(key *PrimaryKey) error {
 	err := dedup(key, nil)
 	if err != nil {

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -107,7 +107,11 @@ func NewServer(settings *Settings) (*Server, error) {
 
 	s.metricsListener = metrics.NewMetrics(settings.Metrics)
 
-	options := []hkp.HandlerOption{hkp.StatsFunc(s.stats)}
+	options := []hkp.HandlerOption{
+		hkp.StatsFunc(s.stats),
+		hkp.SelfSignedOnly(settings.HKP.Queries.SelfSignedOnly),
+		hkp.FingerprintOnly(settings.HKP.Queries.FingerprintOnly),
+	}
 	if settings.IndexTemplate != "" {
 		options = append(options, hkp.IndexTemplate(settings.IndexTemplate))
 	}

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -44,10 +44,19 @@ const (
 
 type HKPConfig struct {
 	Bind string `toml:"bind"`
+
+	Queries queryConfig `toml:"queries"`
+}
+
+type queryConfig struct {
+	// Only respond with verified self-signed key material in queries
+	SelfSignedOnly bool `toml:"selfSignedOnly"`
+	// Only allow fingerprint / key ID queries; no UID keyword searching allowed
+	FingerprintOnly bool `toml:"keywordSearchDisabled"`
 }
 
 type HKPSConfig struct {
-	HKPConfig
+	Bind string `toml:"bind"`
 	Cert string `toml:"cert"`
 	Key  string `toml:"key"`
 }


### PR DESCRIPTION
These options prevent Hockeypuck from propagating keyring spam to GnuPG.

"Self-signed only" option removes all packets that are not "self-signed"
by the primary key.

"Fingerprint only" option only allows fingerprint and key ID queries --
no email addresses or name searches.

These options only affect queries; all uploaded key material is still
stored and synchronized with peers. They are not enabled by default.