### PR TITLE
Remove unused release architectures from debian/control.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.5
 Homepage: https://hockeypuck.github.io/
 
 Package: hockeypuck
-Architecture: i386 amd64 armhf
+Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, adduser
 Conflicts: hockeypuck (<< 2)
 Recommends:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,6 +5,10 @@ description: |
   Hockeypuck is an OpenPGP Key Server that implements the HTTP
   Keyserver Protocol and the SKS database reconciliation protocol.
 
+architectures:
+- build-on: amd64
+  run-on: amd64
+
 base: core18
 confinement: strict
 grade: stable
@@ -39,7 +43,7 @@ parts:
       # https://github.com/golang/go/issues/33840
       - CGO_ENABLED: "0"
     build-snaps:
-      - go
+      - go/1.12/stable
     plugin: make
     make-parameters:
       - prefix=


### PR DESCRIPTION
Not supporting other release architectures until there is demand for it.