### PR TITLE
Update templates to be compatible with sks-keyservers.net

### DIFF
--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -11,20 +11,25 @@ table, th, td {
 </style></head><body><h1>Hockeypuck OpenPGP Keyserver Statistics</h1>
 Taken at {{ .Now }}
 <h2>Settings</h2>
-<table>
-<tr><th>Version</th><td>{{ .Version }} </td></tr>
-{{ if .Contact }}<tr><th>Server Contact</th><td>{{ .Contact }} </td></tr>{{ end }}
-<tr><th>HTTP</th><td>{{ .HTTPAddr }} </td></tr>
-<tr><th>Recon</th><td>{{ .ReconAddr }} </td></tr>
+     <table summary="Keyserver Settings">
+     <tr><td>Hostname:</td><td>{{ .Hostname }}</td></tr>
+     <tr><td>Nodename:</td><td>{{ .Nodename }}</td></tr>
+     <tr><td>Version:</td><td>1.1.6+</td></tr>
+     <tr><td>Server contact:</td><td>{{ .Contact }}</td></tr>
+     <tr><td>HTTP port:</td><td>{{ .HTTPAddr }}</td></tr>
+     <tr><td>Recon port:</td><td>{{ .ReconAddr }}</td></tr>
 </table>
 
-<h3>Gossip Peers</h3>
-<table><tr><th>Name</th><th>HTTP</th><th>Recon</th></tr>
-{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td></tr>
+<table summary="Keyserver Peers" width="100%">
+<tr valign="top"><td>
+<h2>Gossip Peers</h2>
+<table summary="Gossip Peers">
+{{ range $peer := .Peers }}<tr><td>{{ $peer.ReconAddr }}</td></tr>
 {{ end }}</table>
+</td><td>
+</table>
 
-<h2>Statistics</h2>
-Total number of keys: {{ .Total }}
+<h2>Statistics</h2><p>Total number of keys: {{ .Total }}</p>
 
 <h3>Daily Histogram</h3>
 <table><tr><th>Day</th><th>New Keys</th><th>Updated Keys</th></tr>

--- a/contrib/webroot/404.html
+++ b/contrib/webroot/404.html
@@ -100,9 +100,6 @@
             <a href="/pks/lookup?op=stats">statistics</a>
           </p>
         </div>
-        <div style="float:right;">
-          <p class="muted credit small">Provided as a public service by <a href="#" data-toggle="modal" data-target="#contact">###ENTERNAMEHERE###</a>.</p>
-        </div>
       </div>
     </div>
   </body>

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: hockeypuck
 Section: net
 Priority: optional
 Maintainer: Casey Marshall <cmars@cmarstech.com>
-Build-Depends: debhelper (>= 9), golang-1.12, dh-systemd (>= 1.5)
+Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5)
 Standards-Version: 3.9.5
 Homepage: https://hockeypuck.github.io/
 

--- a/debian/hockeypuck.service
+++ b/debian/hockeypuck.service
@@ -6,7 +6,7 @@ After=network.target
 User=hockeypuck
 Group=hockeypuck
 LimitNOFILE=49152
-Environment=HOME=/var/lib/hockeypuck
+WorkingDirectory=/var/lib/hockeypuck
 ExecStart=/usr/bin/hockeypuck -config /etc/hockeypuck/hockeypuck.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -30,8 +30,6 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/lib/pq v1.1.1
 	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/phyber/negroni-gzip v0.0.0-20180113114010-ef6356a5d029 // indirect

--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -371,7 +371,7 @@ func (h *Handler) stats(w http.ResponseWriter, l *Lookup) {
 		return
 	}
 
-	if h.statsTemplate != nil && !(l.Options[OptionJSON] || l.Options[OptionMachineReadable]) {
+	if h.statsTemplate != nil && !(l.Options[OptionJSON]) {
 		err = h.statsTemplate.Execute(w, data)
 	} else {
 		err = json.NewEncoder(w).Encode(data)

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -247,7 +247,7 @@ func (s *Server) stats() (interface{}, error) {
 		result.Peers = append(result.Peers, statsPeer{
 			Name:      k,
 			HTTPAddr:  v.HTTPAddr,
-			ReconAddr: v.ReconAddr,
+			ReconAddr: strings.ReplaceAll(v.ReconAddr, ":", " "),
 		})
 	}
 	sort.Sort(statsPeers(result.Peers))


### PR DESCRIPTION
Thank you so much for building hockeypuck, it's been immensely more stable than SKS in my experience. However, I'd still like to gossip with SKS installations so I tweaked hockeypuck to look like SKS and be compatible with [sks-keyservers.net](https://sks-keyservers.net/status/).

Sadly their crawler parses the HTML (even though a nice JSON API is available) and expect the markup to be the same as SKS.

This commit also fixes a few things to be able to build the Debian package with `debuild`.

