### PR TITLE
Update hockeypuck wrapper to support cpu and memory profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Or use LXD for a lighter-weight isolated build:
 
     SNAPCRAFT_BUILD_ENVIRONMENT=lxd snapcraft snap
 
+Enabling cpu or memory profiling:
+
+    sudo snap set hockeypuck cpuprof=1
+    sudo snap set hockeypuck memprof=1
+    sudo systemctl restart snap.hockeypuck.hockeypuck.service
+
+Disabling cpu or memory profiling:
+
+    sudo snap unset hockeypuck cpuprof
+    sudo snap unset hockeypuck memprof
+    sudo systemctl restart snap.hockeypuck.hockeypuck.service
+
 ## Ubuntu package maintainers
 
 In order to release a new version of hockeypuck:

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/src/hockeypuck/server/snap/hockeypuck-wrapper
+++ b/src/hockeypuck/server/snap/hockeypuck-wrapper
@@ -3,10 +3,20 @@
 set -euo pipefail
 
 CONFIG=$SNAP_COMMON/config
+ARGS="-config $CONFIG"
 if [ ! -f "$CONFIG" ]; then
 	echo "Missing config file $CONFIG."
 	echo "Use 'hockeypuck.config' to create/edit config file"
 	exit 1
 fi
 
-exec $SNAP/bin/hockeypuck -config $CONFIG
+CPUPROF="$(snapctl get cpuprof)"
+MEMPROF="$(snapctl get memprof)"
+if [ -n "$CPUPROF" ]; then
+    ARGS="$ARGS -cpuprof"
+fi
+if [ -n "$MEMPROF" ]; then
+    ARGS="$ARGS -memprof"
+fi
+
+exec $SNAP/bin/hockeypuck $ARGS


### PR DESCRIPTION
This PR provides users with the ability to run the hockeypuck server with memory and cpu profiling via snap configuration options.