### PR TITLE
Fix/improve docker support (and update environment)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /.git
 /.gocache
 /**/secrets
+/keydump

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 /pkg
 /contrib/pyinfra
 /.git
+/.gocache
 /**/secrets

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 .gocache
 .venv
 /bin
+/etc
 /pkg
+/keydump
 __pycache__
 debian/files
 version-git-commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ RUN mkdir -p /hockeypuck/bin /hockeypuck/lib /hockeypuck/etc /hockeypuck/data
 COPY --from=builder /hockeypuck/bin /hockeypuck/bin
 COPY --from=builder /hockeypuck/contrib/templates /hockeypuck/lib/templates
 COPY --from=builder /hockeypuck/contrib/webroot /hockeypuck/lib/www
+COPY --from=builder /hockeypuck/contrib/docker-compose/devel/hockeypuck/bin/startup.sh /hockeypuck/bin
 VOLUME /hockeypuck/etc /hockeypuck/data
-CMD ["/hockeypuck/bin/hockeypuck", "-config", "/hockeypuck/etc/hockeypuck.conf"]
+CMD ["/hockeypuck/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:buster as builder
 RUN adduser builder --system --disabled-login
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get -y install build-essential postgresql-11 postgresql-server-dev-11 --no-install-recommends
-COPY --chown=builder:root . /hockeypuck
+COPY --chown=builder:root Makefile /hockeypuck/
+COPY --chown=builder:root src /hockeypuck/src
 ENV GOPATH=/hockeypuck
 USER builder
 WORKDIR /hockeypuck
@@ -13,8 +14,8 @@ RUN cd src/hockeypuck && go install hockeypuck/server/cmd/...
 FROM debian:buster-slim
 RUN mkdir -p /hockeypuck/bin /hockeypuck/lib /hockeypuck/etc /hockeypuck/data
 COPY --from=builder /hockeypuck/bin /hockeypuck/bin
-COPY --from=builder /hockeypuck/contrib/templates /hockeypuck/lib/templates
-COPY --from=builder /hockeypuck/contrib/webroot /hockeypuck/lib/www
-COPY --from=builder /hockeypuck/contrib/docker-compose/devel/hockeypuck/bin/startup.sh /hockeypuck/bin
+COPY contrib/templates /hockeypuck/lib/templates
+COPY contrib/webroot /hockeypuck/lib/www
+COPY contrib/docker-compose/devel/hockeypuck/bin/startup.sh /hockeypuck/bin/
 VOLUME /hockeypuck/etc /hockeypuck/data
 CMD ["/hockeypuck/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,19 @@
-FROM golang:1.15 AS toolchain
-
-FROM ubuntu:18.04 as builder
+FROM golang:buster as builder
 RUN adduser builder --system --disabled-login
-COPY --from=toolchain /usr/local/go /usr/local/go
-ENV PATH="/usr/local/go/bin:/usr/lib/postgresql/10/bin:${PATH}"
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -qq && apt-get -y install build-essential postgresql-10 postgresql-server-dev-10 ca-certificates --no-install-recommends
+RUN apt-get update -qq && apt-get -y install build-essential postgresql-11 postgresql-server-dev-11 --no-install-recommends
 COPY --chown=builder:root . /hockeypuck
 ENV GOPATH=/hockeypuck
 USER builder
 WORKDIR /hockeypuck
 RUN make lint test test-postgresql
-RUN go install hockeypuck/server/cmd/...
-ENTRYPOINT ["/bin/bash"]
+RUN cd src/hockeypuck && go install hockeypuck/server/cmd/...
 
 
-FROM ubuntu:18.04
-RUN apt-get update -qq && apt-get dist-upgrade -y && apt-get -y install ca-certificates --no-install-recommends
+FROM debian:buster-slim
 RUN mkdir -p /hockeypuck/bin /hockeypuck/lib /hockeypuck/etc /hockeypuck/data
 COPY --from=builder /hockeypuck/bin /hockeypuck/bin
 COPY --from=builder /hockeypuck/contrib/templates /hockeypuck/lib/templates
 COPY --from=builder /hockeypuck/contrib/webroot /hockeypuck/lib/www
 VOLUME /hockeypuck/etc /hockeypuck/data
-ENTRYPOINT ["/hockeypuck/bin/hockeypuck", "-config", "/hockeypuck/etc/hockeypuck.conf"]
+CMD ["/hockeypuck/bin/hockeypuck", "-config", "/hockeypuck/etc/hockeypuck.conf"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 PROJECTPATH = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 export GOPATH := $(PROJECTPATH)
 export GOCACHE := $(GOPATH)/.gocache
-export GOROOT :=
-export PATH := /usr/lib/go-1.12/bin:$(PATH)
+export SRCDIR := $(PROJECTPATH)src/hockeypuck
 
 project = hockeypuck
 
@@ -44,27 +43,26 @@ install:
 	cp -a contrib/webroot/* $(DESTDIR)$(statedir)/www
 
 install-build-depends:
-	sudo apt-add-repository -y ppa:canonical-sysadmins/golang
 	sudo apt install -y \
 	    debhelper \
 		dh-systemd \
 	    git-buildpackage \
-	    golang-1.12  # Requires ppa:canonical-sysadmins/golang
+	    golang
 
 lint: lint-go
 
 lint-go:
-	go fmt $(project)/...
-	go vet $(project)/...
+	cd $(SRCDIR) && go fmt $(project)/...
+	cd $(SRCDIR) && go vet $(project)/...
 
 test: test-go
 
 test-go:
-	go test $(project)/...
+	cd $(SRCDIR) && go test $(project)/...
 
 test-postgresql:
-	POSTGRES_TESTS=1 go test $(project)/pghkp/...
-	POSTGRES_TESTS=1 go test $(project)/pgtest/...
+	cd $(SRCDIR) && POSTGRES_TESTS=1 go test $(project)/pghkp/...
+	cd $(SRCDIR) && POSTGRES_TESTS=1 go test $(project)/pgtest/...
 
 #
 # Generate targets to build Go commands.
@@ -75,7 +73,7 @@ define make-go-cmd-target
 	$(eval cmd_target := $(cmd_name))
 
 $(cmd_target):
-	go install $(cmd_package)
+	cd $(SRCDIR) && go install $(cmd_package)
 
 build: $(cmd_target)
 
@@ -91,14 +89,14 @@ define make-go-pkg-target
 	$(eval pkg_target := $(subst /,-,$(pkg_path)))
 
 coverage-$(pkg_target):
-	go test $(pkg_path) -coverprofile=cover.out
-	go tool cover -html=cover.out
+	cd $(SRCDIR) && go test $(pkg_path) -coverprofile=${PROJECTPATH}/cover.out
+	cd $(SRCDIR) && go tool cover -html=${PROJECTPATH}/cover.out
 	rm cover.out
 
 coverage: coverage-$(pkg_target)
 
 test-$(pkg_target):
-	go test $(pkg_path)
+	cd $(SRCDIR) && go test $(pkg_path)
 
 test-go: test-$(pkg_target)
 

--- a/contrib/docker-compose/devel/hockeypuck/bin/startup.sh
+++ b/contrib/docker-compose/devel/hockeypuck/bin/startup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Ensure that some data has been imported before running the server
+
+hkp=/hockeypuck
+bin=$hkp/bin
+config=$hkp/etc/hockeypuck.conf
+
+data=$hkp/data
+ptree=$data/ptree
+
+keydump=$hkp/keydump
+timestamp=$keydump/.import-timestamp
+
+if [ ! -f $config ]
+then
+  cat << EOF >&2
+$config missing, please copy from
+./contrib/docker-compose/devel/hockeypuck/etc and adapt.
+ABORTING
+EOF
+  exit 1
+fi
+
+if ! grep -q '^path=' $config
+then
+  cat << EOF >&2
+Path for prefix tree missing from $config,
+please correct (see ./contrib/docker-compose/devel/hockeypuck/etc)
+and restart.
+ABORTING
+EOF
+  exit 1
+fi
+
+if ! grep -q "^path=\"$ptree\"" $config
+then
+  # Case 1. Update from a previous version: do not try to perform an
+  # (unnecessary, slow) import
+  echo "Non-standard or previous setup found: Skipping keydump import"
+elif [ ! -d $ptree -o ! -f $timestamp ]
+then
+  # Case 2: First run: make sure we run an import
+  if ! ls $keydump/*.pgp >/dev/null 2>&1
+  then
+    cat << EOF >&2
+First run detected but no keydump available. Please obtain one from e.g.
+https://github.com/SKS-Keyserver/sks-keyserver/wiki/KeydumpSources and
+put it in ./keydump
+ABORTING
+EOF
+    exit 1
+  else
+    mkdir -p $ptree
+    echo "Importing PGP files from keydump..."
+    $bin/hockeypuck-load -config $config $keydump/\*.pgp || exit 1
+    touch $timestamp
+  fi
+else
+  # Case 3: Further runs: only perform an import, if things have been updated.
+  # This is rare, but here as it is hard to stop the daemon from auto-starting.
+  echo "Importing any PGP files newer than the timestamp..."
+  find $keydump -name "*.pgp" -newer $timestamp -print0 | \
+    xargs -0r $bin/hockeypuck-load -config $config || exit 1
+fi
+
+echo "Starting hockeypuck daemon..."
+exec $bin/hockeypuck -config $config

--- a/contrib/docker-compose/devel/hockeypuck/etc/hockeypuck.conf
+++ b/contrib/docker-compose/devel/hockeypuck/etc/hockeypuck.conf
@@ -4,6 +4,8 @@ indexTemplate="/hockeypuck/lib/templates/index.html.tmpl"
 vindexTemplate="/hockeypuck/lib/templates/index.html.tmpl"
 statsTemplate="/hockeypuck/lib/templates/stats.html.tmpl"
 webroot="/hockeypuck/lib/www"
+#contact="0x0123456789ABCDEF"
+#hostname="keyserver.example.com"
 
 [hockeypuck.hkp]
 bind=":11371"
@@ -11,6 +13,9 @@ bind=":11371"
 #[hockeypuck.hkp.queries]
 #selfSignedOnly=false
 #keywordSearchDisabled=false
+
+[hockeypuck.conflux.recon.leveldb]
+path="/hockeypuck/data/ptree"
 
 [hockeypuck.openpgp.db]
 driver="postgres-jsonb"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     depends_on:
     - postgres
     volumes:
-    - ./contrib/docker-compose/devel/hockeypuck/etc:/hockeypuck/etc
+    - ./etc:/hockeypuck/etc
+    - ./keydump:/hockeypuck/keydump
     - hkp_data:/hockeypuck/data
 
   postgres:

--- a/src/hockeypuck/openpgp/subkey.go
+++ b/src/hockeypuck/openpgp/subkey.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"strings"
 
-	"golang.org/x/crypto/openpgp/packet"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/openpgp/packet"
 )
 
 type SubKey struct {

--- a/src/hockeypuck/openpgp/userid.go
+++ b/src/hockeypuck/openpgp/userid.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"golang.org/x/crypto/openpgp/packet"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/openpgp/packet"
 )
 
 type UserID struct {

--- a/src/hockeypuck/openpgp/verify.go
+++ b/src/hockeypuck/openpgp/verify.go
@@ -21,8 +21,8 @@ import (
 	"crypto"
 	"hash"
 
-	"golang.org/x/crypto/openpgp/packet"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/openpgp/packet"
 )
 
 func (pubkey *PrimaryKey) verifyPublicKeySelfSig(signed *PublicKey, sig *Signature) error {


### PR DESCRIPTION
While trying to document the steps I had to do for getting docker to run, I noticed that many things are more complicated than necessary:

- `2.1.0` and `master` would not build with docker (see #104)
- Loading a keydump was hard
- The usage of docker `ENTRYPOINT` made loading keys even harder

I also noticed that old system images (Ubuntu 18.04) and Go versions (mixture of 1.12/1.15(?)) were used and that the current build process would stop running on current Go (1.16). The copying of binaries from the `toolchain` looked fragile.

Here is version that simplifies and changes/fixes these things:

- Builds with docker again (fixes #104)
- Uses recent images (I noticed [`golang:buster`](https://hub.docker.com/_/golang?tab=tags&page=1&ordering=last_updated) and therefore started basing everything on buster); no longer needs `toolchain` image
- Uses recent `go` (1.16, even though I do not like the current `cd $(SRCDIR) && go …` hack that is necessary to support the changes to [`$GOPATH`](https://github.com/golang/go/wiki/GOPATH). I am a `go` noob, so maybe there is a better option?
- Loads a keydump from `./keydump` on first run (and is able to add further files later on)
- Uses docker `CMD`, so it is possible to use `docker-compose exec` for diagnosis and fixes
- Makes better use of the docker build cache
- Improves the `hockeypuck.conf` template for docker users
- Incorporates the changes that `go fmt` creates (such that `go fmt` during the build process essentially becomes a no-op).

I'm open to comments and improvements.