### PR TITLE
Reduce load on peers

### DIFF
--- a/src/hockeypuck/go.mod
+++ b/src/hockeypuck/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/goods/httpbuf v0.0.0-20120503183857-5709e9bb814c // indirect
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/interpose/middleware v0.0.0-20150216143757-05ed56ed52fa // indirect
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/justinas/nosurf v0.0.0-20190416172904-05988550ea18 // indirect

--- a/src/hockeypuck/go.sum
+++ b/src/hockeypuck/go.sum
@@ -157,6 +157,7 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/src/hockeypuck/hkp/sks/recon.go
+++ b/src/hockeypuck/hkp/sks/recon.go
@@ -46,8 +46,8 @@ const (
 	httpClientTimeout      = 30
 	maxKeyRecoveryAttempts = 10
 	maxRequestChunkSize    = 100
-	minRequestChunkSize    = 10
-	seenCacheSize          = 4096
+	minRequestChunkSize    = 1
+	seenCacheSize          = 16384
 )
 
 type keyRecoveryCounter map[string]int
@@ -299,7 +299,7 @@ func (r *Peer) requestRecovered(rcvr *recon.Recover) error {
 		}
 		if err != nil {
 			// Failure: Multiplicate Decrease and end Slow Start.
-			r.requestChunkSize = chunksize / 2
+			r.requestChunkSize = len(chunk) / 2
 			r.slowStart = false
 			if r.requestChunkSize < minRequestChunkSize {
 				r.requestChunkSize = minRequestChunkSize

--- a/src/hockeypuck/hkp/sks/recon.go
+++ b/src/hockeypuck/hkp/sks/recon.go
@@ -265,9 +265,13 @@ func (r *Peer) requestRecovered(rcvr *recon.Recover) error {
 			chunksize = len(items)
 		}
 		chunk := items[:chunksize]
-		items = items[chunksize:]
 
 		err := r.requestChunk(rcvr, chunk)
+		if err == nil || chunksize <= minRequestChunkSize {
+			// Advance chunk window if successful or already at minimum size.
+			// (If it failed, we will retry with a smaller chunk size.)
+			items = items[chunksize:]
+		}
 		if err != nil {
 			// Failure: Multiplicative Decrease and end Slow Start.
 			r.requestChunkSize = chunksize / 2


### PR DESCRIPTION
Blacklisting keys and imposing packet/key size limits as done by Hockeypuck reduces the database size locally. However, these keys (typically of abusive length) will be re-requested on every reconciliation attempt, in vain. This causes a huge, unnecessary burden on those peers, possibly even resulting in denial of service. Sometimes, just requesting a chunk of these keys results in a timeout, due to the remote processing involved.

This PR addresses this in two ways:

# Adaptive request chunk sizes

I have had several requests fail (requesting many huge keys in one request, resulting in >30 s work at the other side and thus timeout) more or less continuously. This ensures that we are much more likely to make progress now, while trying to be nicer to our peers.

The request chunk size is adaptive between 10 and 100 (the previous default), borrowing from TCP Slow Start and AIMD:
* Start with the minimum request size (10) and double it, unless an error occurs or the maximum request chunk size is reached (100) ("Slow Start")
* Whenever an error occurs, halve the request size, down to a minimum size ("Multiplicative Decrease" part of AIMD), immediately retrying with the smaller request size, hoping it will succeed
* After a successful request, increase the request chunk size by one ("Additive Increase" part of AIMD).

(The failing chunk is re-requested *immediately* in smaller steps, as the chunk size might already have grown back by the time it is retried in the next reconciliation run, if many other keys are to be synced as well.)

# Avoiding unproductive re-requests

The main impact of reducing load on the peers and DoS potential, however, is achieved by not re-requesting a key when it is clear that this key will not improve our database state. For example, applying filters such as packet deduplication or packet/key size limits will cause the key (and thus its hash) to remain different between the two peers, independently of how often that key is downloaded.

I would have preferred a solution where the hash of a key which would result in an "unchanged" upsert result would be stored in an in-memory list and not requested again. This list would be global, and thus shared by reconciliation attempts with all peers. However, I did not find an easy way to link that result with the original hash in the `hashquery`.

This PR implements a different approach:
1. Whenever a `hashquery` is successfully answered by the peer, it is assumed that it has answered all it knows about these hashes; therefore, requesting those hashes again will not make a difference. So, all the hashes are stored in a `seenCache`.
2. Further requests will refrain from requesting anything in the `seenCache`.

The downside is that too many elements are stored in the `seenCache`, even elements which would never again show up in the recovery set. However, it is easy to implement in one place, with no cross-layer dependencies.

On every start of the server, the keys are requested once, causing some load on the peers. However, this is now only once and not once every minute. This bootstrap request is also necessary to cope with potential changes in the local filtering policy.

The cache is a per-peer LRU cache of 4096 elements, right now:
* Per-peer, because an error in a peer's reply would prevent a key (or update) from being received from any other peer. (Keeping per-peer state would probably not be necessary in the "unchanged" approach, depending on how it actually were implemented.)
* The size should be big enough to cover the number of keys that will have filters applied *plus* the size of a typical reconciliation run, to prevent eviction. (Switching to a significantly bigger cache size and/or an [ARC](https://pkg.go.dev/github.com/hashicorp/golang-lru#ARCCache) might be more prudent, but will require more per-peer state.)

