### PR TITLE
Allow weighted peers

### DIFF
--- a/src/hockeypuck/conflux/recon/gossip.go
+++ b/src/hockeypuck/conflux/recon/gossip.go
@@ -95,14 +95,14 @@ var ErrPeerBusy error = fmt.Errorf("peer is busy handling another request")
 var ErrReconDone = fmt.Errorf("reconciliation done")
 
 func (p *Peer) choosePartner() (net.Addr, error) {
-	partners, err := p.settings.PartnerAddrs()
+	partner, err := p.settings.RandomPartnerAddr()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if len(partners) == 0 {
+	if partner == nil {
 		return nil, errors.WithStack(ErrNoPartners)
 	}
-	return partners[rand.Intn(len(partners))], nil
+	return partner, nil
 }
 
 func (p *Peer) InitiateRecon(addr net.Addr) error {

--- a/src/hockeypuck/go.mod
+++ b/src/hockeypuck/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/goods/httpbuf v0.0.0-20120503183857-5709e9bb814c // indirect
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/interpose/middleware v0.0.0-20150216143757-05ed56ed52fa // indirect
+	github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/justinas/nosurf v0.0.0-20190416172904-05988550ea18 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
@@ -26,6 +27,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.8.0
 	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f // indirect
+	github.com/mroth/weightedrand v0.4.1
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/phyber/negroni-gzip v0.0.0-20180113114010-ef6356a5d029 // indirect
 	github.com/pkg/errors v0.9.1

--- a/src/hockeypuck/go.mod
+++ b/src/hockeypuck/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.8.0
 	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f // indirect
-	github.com/mroth/weightedrand v0.4.1
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/phyber/negroni-gzip v0.0.0-20180113114010-ef6356a5d029 // indirect
 	github.com/pkg/errors v0.9.1

--- a/src/hockeypuck/go.sum
+++ b/src/hockeypuck/go.sum
@@ -229,8 +229,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/mroth/weightedrand v0.4.1 h1:rHcbUBopmi/3x4nnrvwGJBhX9d0vk+KgoLUZeDP6YyI=
-github.com/mroth/weightedrand v0.4.1/go.mod h1:3p2SIcC8al1YMzGhAIoXD+r9olo/g/cdJgAD905gyNE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=

--- a/src/hockeypuck/go.sum
+++ b/src/hockeypuck/go.sum
@@ -170,6 +170,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/interpose/middleware v0.0.0-20150216143757-05ed56ed52fa h1:qNekpdDoyqEJExIrafsr2BS1PDRZk/lI73kK/rfVv6A=
 github.com/interpose/middleware v0.0.0-20150216143757-05ed56ed52fa/go.mod h1:eMb40EJpwUTKSRRKJ3sol3zWoy49dJXNxx7bdciFeYo=
+github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff h1:6NvhExg4omUC9NfA+l4Oq3ibNNeJUdiAF3iBVB0PlDk=
+github.com/jmcvetta/randutil v0.0.0-20150817122601-2bb1b664bcff/go.mod h1:ddfPX8Z28YMjiqoaJhNBzWHapTHXejnB5cDCUWDwriw=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -227,6 +229,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mroth/weightedrand v0.4.1 h1:rHcbUBopmi/3x4nnrvwGJBhX9d0vk+KgoLUZeDP6YyI=
+github.com/mroth/weightedrand v0.4.1/go.mod h1:3p2SIcC8al1YMzGhAIoXD+r9olo/g/cdJgAD905gyNE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=


### PR DESCRIPTION
Allows tuning the probability of starting an (outgoing) gossip interaction with a peer. Instead of evenly distributing the load, now we have a weighted probability, controlled by the new `weight=<n>` option to `hockeypuck.conflux.recon.partner.*`.

The default weight is set at `100`; setting a weight to `-1` (or any negative value) will prevent the peer from being picked for outgoing gossip. (`0` would be the obvious choice, but unfortunately an explicity 0 cannot be distinguished from the absence of a `weight` parameter, AFAIK.)

Controlling the probability of incoming gossip requests is outside of the scope of this PR; options include blocking the peer or convincing its operator to apply a weight as well.