### PR TITLE
Add OpenPGP headers support

### DIFF
--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -69,6 +69,7 @@ type Handler struct {
 	fingerprintOnly bool
 
 	keyReaderOptions []openpgp.KeyReaderOption
+	keyWriterOptions []openpgp.KeyWriterOption
 }
 
 type HandlerOption func(h *Handler) error
@@ -146,6 +147,13 @@ func FingerprintOnly(fingerprintOnly bool) HandlerOption {
 func KeyReaderOptions(opts []openpgp.KeyReaderOption) HandlerOption {
 	return func(h *Handler) error {
 		h.keyReaderOptions = opts
+		return nil
+	}
+}
+
+func KeyWriterOptions(opts []openpgp.KeyWriterOption) HandlerOption {
+	return func(h *Handler) error {
+		h.keyWriterOptions = opts
 		return nil
 	}
 }
@@ -320,7 +328,7 @@ func (h *Handler) get(w http.ResponseWriter, l *Lookup) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
-	err = openpgp.WriteArmoredPackets(w, keys)
+	err = openpgp.WriteArmoredPackets(w, keys, h.keyWriterOptions...)
 	if err != nil {
 		log.Errorf("get %q: error writing armored keys: %v", l.Search, err)
 	}

--- a/src/hockeypuck/openpgp/io_test.go
+++ b/src/hockeypuck/openpgp/io_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"sort"
+	"strings"
 	stdtesting "testing"
 
 	"golang.org/x/crypto/openpgp/armor"
@@ -341,4 +342,19 @@ func (s *SamplePacketSuite) TestKeyLength(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(keys, gc.HasLen, 1)
 	c.Assert(keys[0].Length, gc.Equals, 8429)
+}
+
+func (s *SamplePacketSuite) TestWriteArmorHeaders(c *gc.C) {
+	var opts []KeyWriterOption
+	b := new(bytes.Buffer)
+
+	opts = append(opts, ArmorHeaderComment("HKP"))
+	opts = append(opts, ArmorHeaderVersion("Hockeypuck 2.1.0"))
+	keys, err := ReadArmorKeys(testing.MustInput("uat.asc"))
+	c.Assert(err, gc.IsNil)
+	err = WriteArmoredPackets(b, keys, opts...)
+	c.Assert(err, gc.IsNil)
+	c.Logf("%s", b.String())
+	c.Assert(strings.Contains(b.String(), "Comment: HKP\n"), gc.Equals, true)
+	c.Assert(strings.Contains(b.String(), "Version: Hockeypuck 2.1.0\n"), gc.Equals, true)
 }

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -95,10 +95,21 @@ const (
 	DefaultNWorkers          = 8
 )
 
+type OpenPGPArmorHeaders struct {
+	Comment string `toml:"comment"`
+	Version string `toml:"version"`
+}
+
+const (
+	DefaultArmorHeaderComment = ""
+	DefaultArmorHeaderVersion = ""
+)
+
 type OpenPGPConfig struct {
-	PKS      *PKSConfig `toml:"pks"`
-	NWorkers int        `toml:"nworkers"`
-	DB       DBConfig   `toml:"db"`
+	PKS      *PKSConfig          `toml:"pks"`
+	NWorkers int                 `toml:"nworkers"`
+	DB       DBConfig            `toml:"db"`
+	Headers  OpenPGPArmorHeaders `toml:"headers"`
 
 	// NOTE: The following options will probably prevent your keyserver from
 	// perfectly reconciling with other keyservers that do not share the same
@@ -137,6 +148,10 @@ type OpenPGPConfig struct {
 func DefaultOpenPGP() OpenPGPConfig {
 	return OpenPGPConfig{
 		NWorkers: DefaultNWorkers,
+		Headers: OpenPGPArmorHeaders{
+			Comment: DefaultArmorHeaderComment,
+			Version: DefaultArmorHeaderVersion,
+		},
 		DB: DBConfig{
 			Driver: DefaultDBDriver,
 			DSN:    DefaultDBDSN,


### PR DESCRIPTION
Closes #83 

This PR will add `Comment` and `Version` headers in an armored OpenPGP key similar to the legacy SKS servers. Both values can be set by an optional TOML definition under OpenPGP:

```
[hockeypuck.openpgp.headers]
comment="Hostname: hkp.power.local"
version="Hockeypuck + SKS compatibility"
```