### PR TITLE
Bulk key insertion to Postgres DB

### DIFF
--- a/src/hockeypuck/hkp/storage/mock/mock.go
+++ b/src/hockeypuck/hkp/storage/mock/mock.go
@@ -53,7 +53,7 @@ type resolverFunc func([]string) ([]string, error)
 type modifiedSinceFunc func(time.Time) ([]string, error)
 type fetchKeysFunc func([]string) ([]*openpgp.PrimaryKey, error)
 type fetchKeyringsFunc func([]string) ([]*storage.Keyring, error)
-type insertFunc func([]*openpgp.PrimaryKey) (int, error)
+type insertFunc func([]*openpgp.PrimaryKey) (int, int, error)
 type replaceFunc func(*openpgp.PrimaryKey) (string, error)
 type updateFunc func(*openpgp.PrimaryKey, string, string) error
 type deleteFunc func(string) (string, error)
@@ -154,12 +154,12 @@ func (m *Storage) FetchKeyrings(s []string) ([]*storage.Keyring, error) {
 	}
 	return nil, nil
 }
-func (m *Storage) Insert(keys []*openpgp.PrimaryKey) (int, error) {
+func (m *Storage) Insert(keys []*openpgp.PrimaryKey) (int, int, error) {
 	m.record("Insert", keys)
 	if m.insert != nil {
 		return m.insert(keys)
 	}
-	return 0, nil
+	return 0, 0, nil
 }
 func (m *Storage) Replace(key *openpgp.PrimaryKey) (string, error) {
 	m.record("Replace", key)

--- a/src/hockeypuck/hkp/storage/storage.go
+++ b/src/hockeypuck/hkp/storage/storage.go
@@ -84,8 +84,11 @@ type Inserter interface {
 	// Insert inserts new public keys if they are not already stored. If they
 	// are, then nothing is changed.
 	// Returns (u, n, err) where
-	// <u> is the number of keys updated
-	// <n> is the number of keys inserted
+	// <u>   is the number of keys updated, if any, in case some PrimaryKey's in
+	//       the input where already in DB (same rfingerprint), but had non-overlapping
+	//       set of subkeys, or signatures etc and, thus, different signatures
+	// <n>   is the number of keys inserted in the DB, if any; keys inserted had no key
+	//       of matching rfingerprint in the DB before
 	// <err> is any errors that have occurred during insertion
 	Insert([]*openpgp.PrimaryKey) (int, int, error)
 }

--- a/src/hockeypuck/hkp/storage/storage.go
+++ b/src/hockeypuck/hkp/storage/storage.go
@@ -84,12 +84,14 @@ type Inserter interface {
 	// Insert inserts new public keys if they are not already stored. If they
 	// are, then nothing is changed.
 	// Returns (u, n, err) where
-	// <u>   is the number of keys updated, if any, in case some PrimaryKey's in
-	//       the input where already in DB (same rfingerprint), but had non-overlapping
-	//       set of subkeys, or signatures etc and, thus, different signatures
+	// <u>   is the number of keys updated, if any. When a PrimaryKey in the input is
+	//       already in the DB (same rfingerprint), but has a different md5 (e.g., because
+	//       of a non-overlapping set of signatures), the keys are merged together. If
+	//       signatures, attributes etc are a subset of those of the key in the DB, the
+	//       input key is considered a duplicate and there is no update.
 	// <n>   is the number of keys inserted in the DB, if any; keys inserted had no key
-	//       of matching rfingerprint in the DB before
-	// <err> is any errors that have occurred during insertion
+	//       of matching rfingerprint in the DB before.
+	// <err> are any errors that have occurred during insertion, or nil if none.
 	Insert([]*openpgp.PrimaryKey) (int, int, error)
 }
 

--- a/src/hockeypuck/hkp/storage/storage.go
+++ b/src/hockeypuck/hkp/storage/storage.go
@@ -83,6 +83,10 @@ type Inserter interface {
 
 	// Insert inserts new public keys if they are not already stored. If they
 	// are, then nothing is changed.
+	// Returns (u, n, err) where
+	// <u> is the number of keys updated
+	// <n> is the number of keys inserted
+	// <err> is any errors that have occurred during insertion
 	Insert([]*openpgp.PrimaryKey) (int, int, error)
 }
 

--- a/src/hockeypuck/hkp/storage/storage.go
+++ b/src/hockeypuck/hkp/storage/storage.go
@@ -83,7 +83,7 @@ type Inserter interface {
 
 	// Insert inserts new public keys if they are not already stored. If they
 	// are, then nothing is changed.
-	Insert([]*openpgp.PrimaryKey) (int, error)
+	Insert([]*openpgp.PrimaryKey) (int, int, error)
 }
 
 // Updater defines the storage API for writing key material.
@@ -223,7 +223,7 @@ func UpsertKey(storage Storage, pubkey *openpgp.PrimaryKey) (kc KeyChange, err e
 		lastKey, err = firstMatch(lastKeys, pubkey.RFingerprint)
 	}
 	if IsNotFound(err) {
-		_, err = storage.Insert([]*openpgp.PrimaryKey{pubkey})
+		_, _, err = storage.Insert([]*openpgp.PrimaryKey{pubkey})
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/src/hockeypuck/pghkp/storage.go
+++ b/src/hockeypuck/pghkp/storage.go
@@ -91,6 +91,157 @@ var drConstraintsSQL = []string{
 	`DROP INDEX subkeys_rfp;`,
 }
 
+var crTempTablesSQL = []string{
+	`CREATE TEMPORARY TABLE IF NOT EXISTS keys_copyin (
+rfingerprint TEXT,
+doc jsonb,
+ctime TIMESTAMP WITH TIME ZONE,
+mtime TIMESTAMP WITH TIME ZONE,
+md5 TEXT,
+keywords tsvector
+)
+`,
+	`CREATE TEMPORARY TABLE IF NOT EXISTS subkeys_copyin (
+rfingerprint TEXT,
+rsubfp TEXT
+)
+`,
+	`CREATE TEMPORARY TABLE IF NOT EXISTS keys_checked (
+rfingerprint TEXT NOT NULL PRIMARY KEY,
+doc jsonb NOT NULL,
+ctime TIMESTAMP WITH TIME ZONE NOT NULL,
+mtime TIMESTAMP WITH TIME ZONE NOT NULL,
+md5 TEXT NOT NULL UNIQUE,
+keywords tsvector
+)
+`,
+	`CREATE TEMPORARY TABLE IF NOT EXISTS subkeys_checked (
+rfingerprint TEXT NOT NULL,
+rsubfp TEXT NOT NULL PRIMARY KEY
+)
+`,
+}
+
+var drTempTablesSQL = []string{
+	`DROP TABLE IF EXISTS subkeys_copyin CASCADE
+`,
+	`DROP TABLE IF EXISTS keys_copyin CASCADE
+`,
+	`DROP TABLE IF EXISTS subkeys_checked CASCADE
+`,
+	`DROP TABLE IF EXISTS keys_checked CASCADE
+`,
+}
+
+var bulkTxSQL = []string{
+	// No NULL fields && No Duplicates allowed: rfingerprint && md5 are UNIQUE in keys_checked
+	// First get the new keys: UNIQUE rfp *and* UNIQUE md5 in the file, but *neither* rfp *nor* md5 that exist in DB.
+	`INSERT INTO keys_checked (rfingerprint, doc, ctime, mtime, md5, keywords) 
+SELECT rfingerprint, doc, ctime, mtime, md5, keywords FROM keys_copyin kcpinA WHERE 
+rfingerprint IS NOT NULL AND doc IS NOT NULL AND ctime IS NOT NULL AND mtime IS NOT NULL AND md5 IS NOT NULL AND 
+(SELECT COUNT (*) FROM keys_copyin kcpinB WHERE kcpinB.rfingerprint = kcpinA.rfingerprint OR 
+                                                kcpinB.md5          = kcpinA.md5) = 1 AND 
+NOT EXISTS (SELECT 1 FROM keys WHERE keys.rfingerprint = kcpinA.rfingerprint OR keys.md5 = kcpinA.md5)
+`,
+	// Keep Duplicates and only Duplicates in keys_copyin:
+	// delete 1st-stage checked-keys & remove tuples with NULLs
+	`DELETE FROM keys_copyin WHERE 
+rfingerprint IS NULL OR doc IS NULL OR ctime IS NULL OR mtime IS NULL OR md5 IS NULL OR 
+EXISTS (SELECT 1 FROM keys_checked WHERE keys_checked.rfingerprint = keys_copyin.rfingerprint)
+`,
+	// Of what remains we want _a single copy_ of those keys that are in-file Duplicates but do not yet exist in DB.
+	// *** ctid field is PostgreSQL-specific; Oracle has ROWID equivalent field ***
+	// ===> If there are different md5 for same rfp, this query allows them into keys_checked: <===
+	// ===>  ***  an intentional error of non-unique rfp, to revert to normal insertion!  ***  <===
+	`INSERT INTO keys_checked (rfingerprint, doc, ctime, mtime, md5, keywords) 
+SELECT rfingerprint, doc, ctime, mtime, md5, keywords FROM keys_copyin WHERE 
+( ctid IN 
+     (SELECT ctid FROM 
+        (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY rfingerprint ORDER BY ctid) rfpEnum FROM keys_copyin) AS dupRfpTAB 
+        WHERE rfpEnum = 1) OR 
+  ctid IN 
+     (SELECT ctid FROM 
+        (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY md5 ORDER BY ctid) md5Enum FROM keys_copyin) AS dupMd5TAB 
+        WHERE md5Enum = 1) ) AND 
+NOT EXISTS (SELECT 1 FROM keys WHERE keys.rfingerprint = keys_copyin.rfingerprint OR
+                                     keys.md5          = keys_copyin.md5)
+`,
+	// Subkeys: No NULL fields && No Duplicates (unique in-file and not exist in DB)
+	// Enforce foreign key constraint by checking both keys_checked and keys_copyin (instead of keys)
+	`INSERT INTO subkeys_checked (rfingerprint, rsubfp) 
+SELECT rfingerprint, rsubfp FROM subkeys_copyin skcpinA WHERE 
+skcpinA.rfingerprint IS NOT NULL AND skcpinA.rsubfp IS NOT NULL AND 
+(SELECT COUNT(*) FROM subkeys_copyin skcpinB WHERE skcpinB.rsubfp = skcpinA.rsubfp) = 1 AND 
+NOT EXISTS (SELECT 1 FROM subkeys WHERE subkeys.rsubfp = skcpinA.rsubfp) AND 
+( EXISTS (SELECT 1 FROM keys_checked WHERE keys_checked.rfingerprint = skcpinA.rfingerprint) OR 
+  EXISTS (SELECT 1 FROM keys_copyin  WHERE keys_copyin.rfingerprint  = skcpinA.rfingerprint) )
+`, // Avoid checking "EXISTS (SELECT 1 FROM keys WHERE keys.rfingerprint = skcpinA.rfingerprint)"
+	// by checking in keys_copyin (despite no indexing): only dups (in-file or _in DB_) still in keys_copyin
+	// -----------------
+	// Has NULL field || It is in subkeys_checked
+	`DELETE FROM subkeys_copyin WHERE 
+rfingerprint IS NULL OR rsubfp IS NULL OR 
+EXISTS (SELECT 1 FROM subkeys_checked WHERE subkeys_checked.rsubfp = subkeys_copyin.rsubfp)
+`,
+	// Single-copy of in-file Dups && not Dups in DB
+	// Enforce foreign key constraint by checking both keys_checked and keys_copyin (instead of keys)
+	// *** ctid field is PostgreSQL-specific; Oracle has ROWID equivalent field ***
+	`INSERT INTO subkeys_checked (rfingerprint, rsubfp) 
+SELECT rfingerprint, rsubfp FROM subkeys_copyin WHERE 
+ctid IN 
+   (SELECT ctid FROM 
+      (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY rsubfp ORDER BY ctid) rsubfpEnum FROM subkeys_copyin) AS dupRsubfpTAB 
+      WHERE rsubfpEnum = 1) AND 
+NOT EXISTS (SELECT 1 FROM subkeys WHERE subkeys.rsubfp = subkeys_copyin.rsubfp) AND 
+( EXISTS (SELECT 1 FROM keys_checked WHERE keys_checked.rfingerprint = subkeys_copyin.rfingerprint) OR 
+  EXISTS (SELECT 1 FROM keys_copyin  WHERE keys_copyin.rfingerprint  = subkeys_copyin.rfingerprint) )
+`, // Avoid checking "EXISTS (SELECT 1 FROM keys WHERE keys.rfingerprint = subkeys_copyin.rfingerprint)"
+	// by checking in keys_copyin (despite no indexing): only dups (in-file or _in DB_) still in keys_copyin
+	// -----------------
+	`INSERT INTO keys (rfingerprint, doc, ctime, mtime, md5, keywords) 
+SELECT rfingerprint, doc, ctime, mtime, md5, keywords FROM keys_checked
+`,
+	`INSERT INTO subkeys (rfingerprint, rsubfp) 
+SELECT rfingerprint, rsubfp FROM subkeys_checked
+`,
+}
+
+var bulkStatsSQL = []string{
+	`SELECT COUNT (*) FROM keys_copyin WHERE 
+rfingerprint IS NULL OR doc IS NULL OR ctime IS NULL OR mtime IS NULL OR md5 IS NULL
+`,
+	`SELECT COUNT (*) FROM subkeys_copyin WHERE 
+rfingerprint IS NULL OR rsubfp IS NULL
+`,
+	`SELECT COUNT (*) FROM keys_copyin WHERE 
+( ( NOT EXISTS (SELECT 1 FROM keys_checked WHERE keys_checked.rfingerprint = keys_copyin.rfingerprint OR
+                                                 keys_checked.md5          = keys_copyin.md5) AND 
+    ctid IN 
+        (SELECT ctid FROM 
+          (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY rfingerprint ORDER BY ctid) rfpEnum FROM keys_copyin) AS dupRfpTAB 
+          WHERE rfpEnum = 1) ) OR 
+  (ctid IN 
+     (SELECT ctid FROM 
+        (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY rfingerprint) rfpEnum FROM keys_copyin) AS dupRfpTAB 
+        WHERE rfpEnum > 1)) ) AND 
+NOT EXISTS (SELECT 1 FROM subkeys_checked WHERE subkeys_checked.rfingerprint = keys_copyin.rfingerprint)
+`,
+	`SELECT COUNT (*) FROM keys_copyin WHERE 
+ctid IN 
+   (SELECT ctid FROM 
+      (SELECT ctid, ROW_NUMBER() OVER (PARTITION BY rfingerprint) rfpEnum FROM keys_copyin) AS dupRfpTAB 
+      WHERE rfpEnum > 1) AND 
+EXISTS (SELECT 1 FROM subkeys_checked WHERE subkeys_checked.rfingerprint = keys_copyin.rfingerprint)
+`,
+	`SELECT COUNT (*) FROM keys_checked
+`,
+	`SELECT COUNT (*) FROM subkeys_checked
+`,
+}
+
+var keys_copyin_temp_table_name = "keys_copyin"
+var subkeys_copyin_temp_table_name = "subkeys_copyin"
+
 // Dial returns PostgreSQL storage connected to the given database URL.
 func Dial(url string, options []openpgp.KeyReaderOption) (hkpstorage.Storage, error) {
 	db, err := sql.Open("postgres", url)
@@ -319,6 +470,7 @@ func (st *storage) FetchKeys(rfps []string) ([]*openpgp.PrimaryKey, error) {
 	}
 
 	var result []*openpgp.PrimaryKey
+	defer rows.Close()	// ...?
 	for rows.Next() {
 		var bufStr string
 		err = rows.Scan(&bufStr)
@@ -362,6 +514,7 @@ func (st *storage) FetchKeyrings(rfps []string) ([]*hkpstorage.Keyring, error) {
 	}
 
 	var result []*hkpstorage.Keyring
+	defer rows.Close()	// ...?
 	for rows.Next() {
 		var bufStr string
 		var kr hkpstorage.Keyring
@@ -409,7 +562,43 @@ func readOneKey(b []byte, rfingerprint string) (*openpgp.PrimaryKey, error) {
 	return keys[0], nil
 }
 
-func (st *storage) insertKey(key *openpgp.PrimaryKey) (isDuplicate bool, retErr error) {
+func (st *storage) upsertKeyOnInsert(pubkey *openpgp.PrimaryKey) (kc hkpstorage.KeyChange, err error) {
+	var lastKey *openpgp.PrimaryKey
+	lastKeys, err := st.FetchKeys([]string{pubkey.RFingerprint})
+	if err == nil {
+		// match primary fingerprint -- someone might have reused a subkey somewhere
+		err = hkpstorage.ErrKeyNotFound
+		for _, key := range lastKeys {
+			if key.RFingerprint == pubkey.RFingerprint {
+				lastKey, err = key, nil
+				break
+			}
+		}
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if pubkey.UUID != lastKey.UUID {
+		return nil, errors.Errorf("upsert key %q lookup failed, found mismatch %q", pubkey.UUID, lastKey.UUID)
+	}
+	lastID := lastKey.KeyID()
+	lastMD5 := lastKey.MD5
+	err = openpgp.Merge(lastKey, pubkey)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if lastMD5 != lastKey.MD5 {
+		err = st.Update(lastKey, lastID, lastMD5)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return hkpstorage.KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: lastKey.KeyID(), NewDigest: lastKey.MD5}, nil
+	}
+	return hkpstorage.KeyNotChanged{ID: lastID, Digest: lastMD5}, nil
+}
+
+func (st *storage) insertKey(key *openpgp.PrimaryKey) (needUpsert bool, retErr error) {
 	tx, err := st.Begin()
 	if err != nil {
 		return false, errors.WithStack(err)
@@ -424,7 +613,7 @@ func (st *storage) insertKey(key *openpgp.PrimaryKey) (isDuplicate bool, retErr 
 	return st.insertKeyTx(tx, key)
 }
 
-func (st *storage) insertKeyTx(tx *sql.Tx, key *openpgp.PrimaryKey) (isDuplicate bool, retErr error) {
+func (st *storage) insertKeyTx(tx *sql.Tx, key *openpgp.PrimaryKey) (needUpsert bool, retErr error) {
 	stmt, err := tx.Prepare("INSERT INTO keys (rfingerprint, ctime, mtime, md5, doc, keywords) " +
 		"SELECT $1::TEXT, $2::TIMESTAMP, $3::TIMESTAMP, $4::TEXT, $5::JSONB, to_tsvector($6) " +
 		"WHERE NOT EXISTS (SELECT 1 FROM keys WHERE rfingerprint = $1)")
@@ -463,50 +652,511 @@ func (st *storage) insertKeyTx(tx *sql.Tx, key *openpgp.PrimaryKey) (isDuplicate
 		// If it doesn't, then something has gone badly awry!
 		return false, errors.Wrapf(err, "rows affected not available when inserting rfp=%q", key.RFingerprint)
 	}
+	if keysInserted == 0 {
+		return true, nil
+	}
 
-	var rowsAffected int64
+	//var rowsAffected int64
 	for _, subKey := range key.SubKeys {
-		result, err := subStmt.Exec(&key.RFingerprint, &subKey.RFingerprint)
+		/*result*/ _, err := subStmt.Exec(&key.RFingerprint, &subKey.RFingerprint)
 		if err != nil {
 			return false, errors.Wrapf(err, "cannot insert rsubfp=%q", subKey.RFingerprint)
 		}
-		if rowsAffected, err = result.RowsAffected(); err != nil {
-			// See above.
-			return false, errors.Wrapf(err, "rows affected not available when inserting rsubfp=%q", subKey.RFingerprint)
-		}
-		keysInserted += rowsAffected
+		/*
+			if rowsAffected, err = result.RowsAffected(); err != nil {
+				// See above.
+				return false, errors.Wrapf(err, "rows affected not available when inserting rsubfp=%q", subKey.RFingerprint)
+			}
+			keysInserted += rowsAffected
+		*/
 	}
-
-	return keysInserted == 0, nil
+	// return keysInserted == 0, nil
+	return false, nil
 }
 
-func (st *storage) Insert(keys []*openpgp.PrimaryKey) (n int, retErr error) {
-	var result hkpstorage.InsertError
-	for _, key := range keys {
-		if count, max := len(result.Errors), maxInsertErrors; count > max {
-			result.Errors = append(result.Errors, errors.Errorf("too many insert errors (%d > %d), bailing...", count, max))
-			return n, result
+func (st *storage) bulkInsertNotifyListeners(/*keysInserted int, */result *hkpstorage.InsertError) {
+	//var notif hkpstorage.KeyChange
+	//notifications := make([]hkpstorage.KeyChange, keysInserted)
+	OK := true
+	rows, err := st.Query("SELECT rfingerprint, md5 FROM keys_checked")
+	if err != nil {
+		result.Errors = append(result.Errors, errors.WithStack(err))
+		// FIXME: Is thit msg correct?
+		log.Warn("querying inserted keys: cannot Notify Listeners of new keys; restart keyserver when possible.")
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rfp, md5 string
+		err = rows.Scan(&rfp, &md5)
+		if err != nil {
+			if err != sql.ErrNoRows {
+				result.Errors = append(result.Errors, errors.Wrap(err, // FIXME: Is this msg correct?
+					"could not read key(s). Notifying Listeners aborted. Restart keyserver when possible"))
+			} else {
+				result.Errors = append(result.Errors, errors.WithStack(err))
+			}
+			return
 		}
-
-		if isDuplicate, err := st.insertKey(key); err != nil {
-			result.Errors = append(result.Errors, err)
-			continue
-		} else if isDuplicate {
-			result.Duplicates = append(result.Duplicates, key)
+		if len(rfp) < 16 {
+			result.Errors = append(result.Errors, errors.Errorf("invalid rfp=%q (length < 16)", rfp))
+			OK = false
+			// TODO: maybe should delete such keys?
 			continue
 		}
-
+		/*
+		notif = hkpstorage.KeyAdded{
+			ID:     openpgp.Reverse(rfp[:16]), // KeyID from rfingerprint
+			Digest: md5,
+		}
+		notifications = append(notifications, notif)
+		*/
 		st.Notify(hkpstorage.KeyAdded{
-			ID:     key.KeyID(),
-			Digest: key.MD5,
-		})
-		n++
+			ID:     openpgp.Reverse(rfp[:16]), // KeyID from rfingerprint
+			Digest: md5,
+		}
+	}
+	err = rows.Err()
+	if err != nil {
+		result.Errors = append(result.Errors, errors.WithStack(err))
+	}
+	if !OK {
+		log.Warn("Skipped some bad keys while Notifying Listeners!")
+	}
+	//st.BulkNotify(notifications)
+}
+
+func (st *storage) bulkInsertGetStats(result *hkpstorage.InsertError) (int, int, int, int) {
+	var maxDups, minDups, keysInserted, subkeysInserted int
+	// Get Duplicate stats
+	err := st.QueryRow(bulkStatsSQL[2]).Scan(&minDups)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying duplicate keys. Stats may be inaccurate.")
+		minDups = 0
+	}
+	// In-file duplicates may be duplicates even if we insert a subkey for a key's rfp
+	// FIXME: This might be costly and could be removed...
+	err = st.QueryRow(bulkStatsSQL[3]).Scan(&maxDups)
+	maxDups += minDups
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying duplicate keys. Stats may be inaccurate.")
+		maxDups = 0
+	}
+	// Get keys/subkeys inserted
+	err = st.QueryRow(bulkStatsSQL[4]).Scan(&keysInserted)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying keys inserted. Stats may be inaccurate.")
+		keysInserted = 0
+	}
+	err = st.QueryRow(bulkStatsSQL[5]).Scan(&subkeysInserted)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying subkeys inserted. Stats may be inaccurate.")
+		subkeysInserted = 0
+	}
+	return maxDups, minDups, keysInserted, subkeysInserted
+}
+
+func (st *storage) bulkInsertSingleTx(bulkJobString, jobDesc []string) (err error) {
+	// In single transaction
+	tx, err := st.Begin()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+		}
+		if err != nil {
+			tx.Rollback()
+		}
+	}()
+
+	for i := 0; i < len(bulkJobString); i++ {
+		bulkTxStmt, err := tx.Prepare(bulkJobString[i])
+		if err != nil {
+			return errors.Wrapf(err, "preparing DB server job %s", jobDesc[i])
+		}
+		_, err = bulkTxStmt.Exec()
+		if err != nil {
+			return errors.Wrapf(err, "issuing DB server job %s", jobDesc[i])
+		}
+		err = bulkTxStmt.Close()
+		if err != nil {
+			return errors.Wrapf(err, "closing DB server job %s", jobDesc[i])
+		}
+	}
+	return err
+}
+
+func (st *storage) bulkInsertCheckSubkeys(result *hkpstorage.InsertError) (nullTuples int, ok bool) {
+	// NULLs stats
+	var numNulls int
+	err := st.QueryRow(bulkStatsSQL[1]).Scan(&numNulls)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying subkeys with NULLs. Stats may be inaccurate.")
+	}
+
+	// (1) Itermediate insert no NULL fields & no Duplicates (in-file or in DB)
+	// (2) Keep only subkeys with Duplicates in subkeys_copyin:
+	//     Delete 1st-stage checked subkeys above & those with NULL fields
+	// (3) Single-copy of in-file Dups & not DB Dups
+	txStrs := []string{bulkTxSQL[3], bulkTxSQL[4], bulkTxSQL[5]}
+	msgStrs := []string{"bulkTx-check subkey no NULLs & no Dups",
+		"bulkTx-report subkeys setup", "bulkTx-check subkeys some Dups"}
+	err = st.bulkInsertSingleTx(txStrs, msgStrs)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		return 0, false
+	}
+	return numNulls, true
+}
+
+func (st *storage) bulkInsertCheckKeys(result *hkpstorage.InsertError) (n int, ok bool) {
+	// NULLs stats
+	var numNulls int
+	err := st.QueryRow(bulkStatsSQL[0]).Scan(&numNulls)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		log.Warn("Error querying keys with NULLs. Stats may be inaccurate.")
+	}
+
+	// (1) rfingerprint & md5 are also UNIQUE in keys_checked so no duplicates inside this same file allowed
+	// (2) Keep only keys with Duplicates in keys_copyin: delete 1st-stage checked keys & tuples with NULL fields
+	// (3) Insert single copy of in-file Duplicates that have no Duplicate in final keys table
+	txStrs := []string{bulkTxSQL[0], bulkTxSQL[1], bulkTxSQL[2]}
+	msgStrs := []string{"bulkTx-check unique rfp & md5", "bulkTx-report setup", "bulkTx-check some Dups"}
+	err = st.bulkInsertSingleTx(txStrs, msgStrs)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		return 0, false
+	}
+	return numNulls, true
+}
+
+func (st *storage) bulkInsertCheckedKeysSubkeys(keys []*openpgp.PrimaryKey,
+	result *hkpstorage.InsertError) (nullKeys, nullSubkeys int, ok bool) {
+	keysOK, subkeysOK := true, true
+	// key batch-processing
+	if nullKeys, keysOK = st.bulkInsertCheckKeys(result); !keysOK {
+		return 0, 0, false
+	}
+	// subkey batch-processing
+	if nullSubkeys, subkeysOK = st.bulkInsertCheckSubkeys(result); !subkeysOK {
+		return 0, 0, false
+	}
+
+	// Batch INSERT all checked-for-constraints keys from memory tables (should need no checks!!!!)
+	// Final batch-insertion in keys/subkeys tables without any checks: _must not_ give any errors
+	txStrs := []string{bulkTxSQL[6], bulkTxSQL[7]}
+	msgStrs := []string{"bulkTx-insert keys", "bulkTx-insert subkeys"}
+	err := st.bulkInsertSingleTx(txStrs, msgStrs)
+	if err != nil {
+		result.Errors = append(result.Errors, err)
+		return 0, 0, false
+	}
+	return nullKeys, nullSubkeys, true
+}
+
+func (st *storage) bulkInsertSendBunchTx(keystmt, msgSpec string, keysValueArgs []interface{}) (err error) {
+	// In single transaction...
+	tx, err := st.Begin()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		} else {
+			tx.Commit()
+		}
+	}()
+
+	stmt, err := tx.Prepare(keystmt)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = stmt.Exec(keysValueArgs...) // All keys in bunch
+	if err != nil {
+		return errors.Wrapf(err, "cannot simply send a bunch of %s to server (too large bunch?)", msgSpec)
+	}
+	err = stmt.Close()
+	if err != nil {
+		return errors.Wrapf(err, "failed to close xfer sending a bunch of %s to server", msgSpec)
+	}
+
+	return nil
+}
+
+func (st *storage) bulkInsertSendBunch(keystmt, subkeystmt string, keysValueArgs, subkeysValueArgs []interface{}) (err error) {
+
+	// Send all keys to in-mem tables to the pg server; *no constraints checked*
+	err = st.bulkInsertSendBunchTx(keystmt, "keys", keysValueArgs)
+	if err != nil {
+		return err
+	}
+
+	// Send all subkeys to in-mem tables to the pg server; *no constraints checked*
+	err = st.bulkInsertSendBunchTx(subkeystmt, "subkeys", subkeysValueArgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type KeyInsertArgs struct {
+	RFingerprint *string
+	jsonStrDoc   *string
+	//	ctime *Time
+	//	mtime *Time
+	MD5      *string
+	keywords *string
+}
+type SubkeyInsertArgs struct {
+	keyRFingerprint    *string
+	subkeyRFingerprint *string
+}
+
+// Insert keys & subkeys to in-mem tables with no constraints at all: should have no errors!
+func (st *storage) bulkInsertDoCopy(keyInsertArgs []KeyInsertArgs, subkeyInsertArgs [][]SubkeyInsertArgs,
+	result *hkpstorage.InsertError) (ok bool) {
+	lenKIA := len(keyInsertArgs)
+	for totKeyArgs, totSubkeyArgs, idx, lastIdx := 0, 0, 0, 0; idx < lenKIA; totKeyArgs, totSubkeyArgs, lastIdx = 0, 0, idx {
+		keysValueStrings := make([]string, 0, 5000)         // could be 10K keys but 5K more uniform for 15K files
+		keysValueArgs := make([]interface{}, 0, 5000*6)     // *** less than 64k arguments ***
+		subkeysValueStrings := make([]string, 0, 32000)     // max 32K subkeys
+		subkeysValueArgs := make([]interface{}, 0, 32000*2) // *** less than 64k arguments ***
+		insTime := make([]time.Time, 0, 5000)               // stupid but anyway...
+		for i, j := 0, 0; idx < lenKIA; idx, i = idx+1, i+1 {
+			lenSKIA := len(subkeyInsertArgs[idx])
+			totKeyArgs += 6
+			totSubkeyArgs += 2 * lenSKIA
+			if (totKeyArgs > 30000) || (totSubkeyArgs > 64000) {
+				totKeyArgs -= 6
+				totSubkeyArgs -= 2 * lenSKIA
+				break
+			}
+			keysValueStrings = append(keysValueStrings,
+				fmt.Sprintf("($%d::TEXT, $%d::JSONB, $%d::TIMESTAMP, $%d::TIMESTAMP, $%d::TEXT, to_tsvector($%d))",
+					i*6+1, i*6+2, i*6+3, i*6+4, i*6+5, i*6+6))
+			insTime = insTime[:i+1] // re-slice +1
+			insTime[i] = time.Now().UTC()
+			keysValueArgs = append(keysValueArgs, *keyInsertArgs[idx].RFingerprint, *keyInsertArgs[idx].jsonStrDoc,
+				insTime[i], insTime[i], *keyInsertArgs[idx].MD5, *keyInsertArgs[idx].keywords)
+
+			for sidx := 0; sidx < lenSKIA; sidx, j = sidx+1, j+1 {
+				subkeysValueStrings = append(subkeysValueStrings, fmt.Sprintf("($%d::TEXT, $%d::TEXT)", j*2+1, j*2+2))
+				subkeysValueArgs = append(subkeysValueArgs,
+					*subkeyInsertArgs[idx][sidx].keyRFingerprint, *subkeyInsertArgs[idx][sidx].subkeyRFingerprint)
+			}
+		}
+		// TODO: remove this & lastIdx (debuging only)
+		log.Infof("Attempting bulk insertion of %d keys and a total of %d subkeys!", idx-lastIdx, totSubkeyArgs>>1)
+		keystmt := fmt.Sprintf("INSERT INTO %s (rfingerprint, doc, ctime, mtime, md5, keywords) VALUES %s",
+			keys_copyin_temp_table_name, strings.Join(keysValueStrings, ","))
+		subkeystmt := fmt.Sprintf("INSERT INTO %s (rfingerprint, rsubfp) VALUES %s",
+			subkeys_copyin_temp_table_name, strings.Join(subkeysValueStrings, ","))
+
+		err := st.bulkInsertSendBunch(keystmt, subkeystmt, keysValueArgs, subkeysValueArgs)
+		if err != nil {
+			// TODO: go on with other bunches??? And then?
+			result.Errors = append(result.Errors, err)
+			return false
+		}
+		log.Infof("%d keys, %d subkeys sent to DB...", idx-lastIdx, totSubkeyArgs>>1) // TODO: remove this & lastIdx
+	}
+	return true
+}
+
+func (st *storage) bulkInsertCopyKeysToServer(keys []*openpgp.PrimaryKey, result *hkpstorage.InsertError) (int, bool) {
+	var key *openpgp.PrimaryKey
+	keyInsertArgs := make([]KeyInsertArgs, 0, len(keys))
+	subkeyInsertArgs := make([][]SubkeyInsertArgs, 0, len(keys))
+	jsonStrs, theKeywords := make([]string, len(keys)), make([]string, len(keys))
+
+	unprocessed, sidx, i := 0, 0, 0
+	for _, key = range keys {
+		openpgp.Sort(key)
+		jsonKey := jsonhkp.NewPrimaryKey(key)
+		jsonBuf, err := json.Marshal(jsonKey)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				errors.Wrapf(err, "pre-processing cannot serialize rfp=%q", key.RFingerprint))
+			unprocessed++
+			continue
+		}
+		jsonStrs[i], theKeywords[i] = string(jsonBuf), keywordsTSVector(key)
+		keyInsertArgs = keyInsertArgs[:i+1] // re-slice +1
+		keyInsertArgs[i] = KeyInsertArgs{&key.RFingerprint, &jsonStrs[i], &key.MD5, &theKeywords[i]}
+
+		subkeyInsertArgs = subkeyInsertArgs[:i+1] // re-slice +1
+		subkeyInsertArgs[i] = make([]SubkeyInsertArgs, 0, len(key.SubKeys))
+		for sidx = 0; sidx < len(key.SubKeys); sidx++ {
+			subkeyInsertArgs[i] = subkeyInsertArgs[i][:sidx+1] // re-slice +1
+			subkeyInsertArgs[i][sidx] = SubkeyInsertArgs{&key.RFingerprint, &key.SubKeys[sidx].RFingerprint}
+		}
+		i++
+	}
+	ok := st.bulkInsertDoCopy(keyInsertArgs, subkeyInsertArgs, result)
+	return unprocessed, ok
+}
+
+func (st *storage) bulkInsertCleanUp() (err error) {
+	// Drop the 2 pairs (all) of temporary tables
+	for _, drTableSQL := range drTempTablesSQL {
+		_, err := st.Exec(drTableSQL)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func (st *storage) bulkInsertCreateTempTables() (err error) {
+	for _, crTableSQL := range crTempTablesSQL {
+		_, err := st.Exec(crTableSQL)
+		if err != nil {
+			return errors.Wrap(err, "cannot drop temporary tables")
+		}
+	}
+	return nil
+}
+
+func (st *storage) BulkInsert(keys []*openpgp.PrimaryKey, result *hkpstorage.InsertError) (int, bool) {
+	log.Infof("Attempting bulk insertion of keys")
+	t := time.Now() // FIXME: Remove this
+	// Create 2 pairs of _temporary_ (i.e., in-mem ??) tables:
+	// (a) keys_copyin, subkeys_copyin
+	// (b) keys_checked, subkeys_checked
+	err := st.bulkInsertCreateTempTables()
+	if err != nil {
+		// This should always be possible. Maybe, out-of-memory? Don\'t retry.
+		result.Errors = append(result.Errors, err)
+		// Drop temp tables IF EXIST
+		st.bulkInsertCleanUp() // don\'t care for any error from this
+		return 0, false
+	}
+	unprocessed, keysWithNulls, subkeysWithNulls, ok := 0, 0, 0, true
+	maxDups, minDups, keysInserted, subkeysInserted := 0, 0, 0, 0
+	// (a): Send *all* keys to in-mem tables on the pg server; *no constraints checked*
+	if unprocessed, ok = st.bulkInsertCopyKeysToServer(keys, result); !ok {
+		// Drop temp tables IF EXIST
+		st.bulkInsertCleanUp() // don\'t care for any error from this
+		return 0, false
+	} else { // TODO: remove this
+		if unprocessed == 0 {
+			log.Infof("After %v: All keys in file sent to DB. Inserting now...", time.Since(t))
+		} else {
+			log.Infof("After %v: %d of all keys in file sent to DB. Inserting now...",
+				time.Since(t), len(keys)-unprocessed)
+		}
+	}
+	t = time.Now() // FIXME: Remove this
+	// (b): From _copyin tables (still only to in-mem table) remove duplicates
+	//      check *all* constraints & RollBack insertions of key/subkeys that err
+	if keysWithNulls, subkeysWithNulls, ok = st.bulkInsertCheckedKeysSubkeys(keys, result); !ok {
+		// Drop temp tables IF EXIST
+		st.bulkInsertCleanUp() // don\'t care for any error from this
+		return 0, false
+	}
+	// TODO: Remove this
+	log.Infof("After %v: Bulk-processed and bulk-inserted keys and subkeys to DB.", time.Since(t))
+
+	t = time.Now() // FIXME: Remove this
+	maxDups, minDups, keysInserted, subkeysInserted = st.bulkInsertGetStats(result)
+	// TODO: Remove this
+	log.Infof("After %v: Processed stats. Notifying Listeners now...", time.Since(t))
+
+	t = time.Now() // FIXME: Remove this
+	st.bulkInsertNotifyListeners(/*keysInserted, */result)
+
+	if minDups == maxDups {
+		log.Infof("After %v: Bulk Insertion OK: %d keys and %d subkeys with NULLs; "+
+			"%d duplicates; %d keys and %d subkeys inserted", time.Since(t),
+			keysWithNulls, subkeysWithNulls, minDups, keysInserted, subkeysInserted)
+	} else {
+		log.Infof("After %v: Bulk Insertion OK: %d keys and %d subkeys with NULLs; "+
+			"at least %d (and up to %d possible) duplicates; %d keys and %d subkeys inserted", time.Since(t),
+			keysWithNulls, subkeysWithNulls, minDups, maxDups, keysInserted, subkeysInserted)
+	}
+
+	err = st.bulkInsertCleanUp()
+	if err != nil {
+		// Temporary tables with previous data may lead to errors,
+		// when attempting insertion of duplicates, in next file,
+		// but may be resolved for the subsequent file(s)
+		result.Errors = append(result.Errors, err)
+	}
+
+	// FIXME: Imitate returning duplicates for reporting. Can be removed.
+	result.Duplicates = make([]*openpgp.PrimaryKey, minDups)
+	return keysInserted, true
+}
+
+func (st *storage) Insert(keys []*openpgp.PrimaryKey) (u, n int, retErr error) {
+	var result hkpstorage.InsertError
+
+	bulkOK, bulkSkip := false, false
+	if len(keys) > 3500 {
+		// Attempt bulk insertion
+		n, bulkOK = st.BulkInsert(keys, &result)
+	} else {
+		bulkSkip = true
+	}
+
+	if !bulkOK {
+		log.Infof("Bulk insertion %s. Reverting to normal insertion.",
+			(map[bool]string{true: "skipped (small number of keys)", false: "failed"})[bulkSkip])
+
+		for _, key := range keys {
+			if count, max := len(result.Errors), maxInsertErrors; count > max {
+				result.Errors = append(result.Errors,
+					errors.Errorf("too many insert errors (%d > %d), bailing...", count, max))
+				return u, n, result
+			}
+
+			if needUpsert, err := st.insertKey(key); err != nil {
+				result.Errors = append(result.Errors, err)
+				continue
+			} else if needUpsert {
+				// TODO: Remove this; only for debug
+				log.Infof("Checking possible key-merge & update, or just dropping of a duplicate.")
+				kc, err := st.upsertKeyOnInsert(key)
+				if err != nil {
+					result.Errors = append(result.Errors, err)
+				} else {
+					switch kc.(type) {
+					case hkpstorage.KeyReplaced:
+						// Listener in hockeypuck-load not really prepared for hkpstorage.KeyReplaced notifications
+						// but stats are updated...
+						st.Notify(kc)
+						u++
+					case hkpstorage.KeyNotChanged:
+						result.Duplicates = append(result.Duplicates, key)
+					default:		// TODO: Remove this; only for debug
+						log.Infof("Unexpected type response from upsertKeyOnInsert().")
+					}
+				}
+				continue
+			} else {
+				st.Notify(hkpstorage.KeyAdded{
+					ID:     key.KeyID(),
+					Digest: key.MD5,
+				})
+				n++
+			}
+		}
 	}
 
 	if len(result.Duplicates) > 0 || len(result.Errors) > 0 {
-		return n, result
+		return u, n, result
 	}
-	return n, nil
+	return u, n, nil
 }
 
 func (st *storage) Replace(key *openpgp.PrimaryKey) (_ string, retErr error) {
@@ -708,6 +1358,21 @@ func (st *storage) Subscribe(f func(hkpstorage.KeyChange) error) {
 	st.listeners = append(st.listeners, f)
 	st.mu.Unlock()
 }
+
+/*
+func (st *storage) BulkNotify(changes []hkpstorage.KeyChange) error {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	log.Debugf("%v", changes)
+	for _, change := range changes {
+		for _, f := range st.listeners {
+			// TODO: log error notifying listener?
+			f(change)
+		}
+	}
+	return nil
+}
+*/
 
 func (st *storage) Notify(change hkpstorage.KeyChange) error {
 	st.mu.Lock()

--- a/src/hockeypuck/server/cmd/hockeypuck-load/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-load/main.go
@@ -133,7 +133,7 @@ func load(settings *server.Settings, args []string) error {
 			}
 			log.Infof("found %d keys in %q...", len(keys), file)
 			t := time.Now()
-			n, err := st.Insert(keys)
+			u, n, err := st.Insert(keys)
 			if err != nil {
 				log.Errorf("some keys failed to insert from %q: %v", file, err)
 				if hke, ok := err.(storage.InsertError); ok {
@@ -142,8 +142,8 @@ func load(settings *server.Settings, args []string) error {
 					}
 				}
 			}
-			if n > 0 {
-				log.Infof("inserted %d keys from %q in %v", n, file, time.Since(t))
+			if n > 0 || u > 0 {
+				log.Infof("inserted %d, updated %d keys from %q in %v", n, u, file, time.Since(t))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #131 

__ 9.5 - 10.5 hours, to load a complete key dump of ~6.13M keys (14GB)
[using Postgres DB config values:
wal_buffers = 16MB
checkpoint_timeout = 2min (this is the important one, I think)
checkpoint_flush_after = 16MB
Others left to defaults.]

__ Time breakdown per 15K-key file:
Sending keys to DB takes: 6.2 - 8.3 sec
Filtering & insertion takes: 43 - 50 sec
Measuring stats takes: 33.5 - 45 msec
Reading keys back takes: 13.5 - 50 sec
Total time per 15K-key file is ~1min 3sec -- ~1min 50sec.

__ Tried a type of "bulk-notify-listeners", which acquires the pghkp storage `mutex` only once for all notifications in a call to `Insert(..)`; this did not seem to change timing behavior, so it is commented-out in the code.

__ One-key-at-a-time insertion updated to merge keys with same `rfingerprint`, when they are not duplicates

__ Bulk insertion reverts to one-key-at-a-time insertion, when there are keys with same `rfingerprint` that have different `md5`

__ _Strangely_, though bulk insertion reverts to one-key-at-a-time insertion, if need for a key update is likely, the three (3) files that trigger this conflict and revert to one-key-at-a-time insertion do not do any key updates at all. _This should be investigated_, I believe. The daily (smaller) dump files do quite a few updates.