### PR TITLE
Don't disable keyword search by default

### DIFF
--- a/contrib/docker-compose/standalone/hockeypuck/etc/hockeypuck.conf.tmpl
+++ b/contrib/docker-compose/standalone/hockeypuck/etc/hockeypuck.conf.tmpl
@@ -14,7 +14,7 @@ bind=":11371"
 
 [hockeypuck.hkp.queries]
 selfSignedOnly=true
-keywordSearchDisabled=true
+#keywordSearchDisabled=true
 
 # prevent abusively large keys
 [hockeypuck.openpgp]


### PR DESCRIPTION
Use more sensible default in standalone hockeypuck config template