### PR TITLE
Fix docker logging configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install-build-depends:
 lint: lint-go
 
 lint-go:
-	cd $(SRCDIR) && go fmt $(project)/...
+	cd $(SRCDIR) && [ -z "$$(go fmt $(project)/...)" ]
 	cd $(SRCDIR) && go vet $(project)/...
 
 test: test-go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     - ./keydump:/hockeypuck/import/dump
     - hkp_data:/hockeypuck/data
     logging:
+      driver: json-file
       options:
         max-size: "10m"
         max-file: "3"

--- a/src/hockeypuck/logrus/terminal_notwindows.go
+++ b/src/hockeypuck/logrus/terminal_notwindows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || darwin || freebsd || openbsd
 // +build linux darwin freebsd openbsd
 
 package logrus

--- a/src/hockeypuck/logrus/terminal_windows.go
+++ b/src/hockeypuck/logrus/terminal_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package logrus

--- a/src/hockeypuck/server/cmd/cmd.go
+++ b/src/hockeypuck/server/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	log "hockeypuck/logrus"
 )
 

--- a/src/hockeypuck/server/cmd/hockeypuck-dump/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-dump/main.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/pkg/errors"
 	"gopkg.in/tomb.v2"
+
 	"hockeypuck/conflux/recon"
 	"hockeypuck/hkp/sks"
 	"hockeypuck/hkp/storage"
 	"hockeypuck/openpgp"
-
 	"hockeypuck/server"
 	"hockeypuck/server/cmd"
 )
@@ -51,7 +51,7 @@ func main() {
 
 	cpuFile := cmd.StartCPUProf(*cpuProf, nil)
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR2)
 	go func() {
 		for {

--- a/src/hockeypuck/server/cmd/hockeypuck-load/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-load/main.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	cf "hockeypuck/conflux"
 	"hockeypuck/hkp/sks"
 	"hockeypuck/hkp/storage"
 	log "hockeypuck/logrus"
 	"hockeypuck/openpgp"
-
 	"hockeypuck/server"
 	"hockeypuck/server/cmd"
 )
@@ -52,7 +52,7 @@ func main() {
 		cmd.Die(errors.New("missing PGP key file arguments"))
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR2)
 	go func() {
 		for {

--- a/src/hockeypuck/server/cmd/hockeypuck-pbuild/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-pbuild/main.go
@@ -8,11 +8,11 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+
 	cf "hockeypuck/conflux"
 	"hockeypuck/hkp/sks"
 	"hockeypuck/hkp/storage"
 	log "hockeypuck/logrus"
-
 	"hockeypuck/server"
 	"hockeypuck/server/cmd"
 )
@@ -43,7 +43,7 @@ func main() {
 
 	cpuFile := cmd.StartCPUProf(*cpuProf, nil)
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR2)
 	go func() {
 		for {

--- a/src/hockeypuck/server/cmd/hockeypuck/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	srv.Start()
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 4)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
 	go func() {
 		for {


### PR DESCRIPTION
Recently docker compose started failing with a journald configuration
error. Specifying the logging driver in the docker compose ensures that
the options match the platform-default driver.