### PR TITLE
Add support for 0x-free FP and long-ID index search #169

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install-build-depends:
 lint: lint-go
 
 lint-go:
-	cd $(SRCDIR) && [ -z "$$(go fmt $(project)/...)" ]
+	cd $(SRCDIR) && ! go fmt $(project)/... | awk '/./ {print "ERROR: go fmt made unexpected changes:", $$0}' | grep .
 	cd $(SRCDIR) && go vet $(project)/...
 
 test: test-go

--- a/src/hockeypuck/conflux/bitstring_test.go
+++ b/src/hockeypuck/conflux/bitstring_test.go
@@ -66,9 +66,9 @@ func (s *BitstringSuite) TestBsBytes(c *gc.C) {
 	for i := 0; i < bs.BitLen(); i++ {
 		switch i {
 		case 0:
-			c.Assert(1, gc.Equals, bs.Get(i))
+			c.Assert(bs.Get(i), gc.Equals, 1)
 		default:
-			c.Assert(0, gc.Equals, bs.Get(i))
+			c.Assert(bs.Get(i), gc.Equals, 0)
 		}
 	}
 }

--- a/src/hockeypuck/conflux/matrix_test.go
+++ b/src/hockeypuck/conflux/matrix_test.go
@@ -43,13 +43,13 @@ func (s *MatrixSuite) TestMatrixPutGet(c *gc.C) {
 		for j := 0; j < TEST_MATRIX_SIZE; j++ {
 			n++
 			if i == 2 && j == 2 {
-				c.Assert(int64(24), gc.Equals, m.Get(i, j).Int64())
+				c.Assert(m.Get(i, j).Int64(), gc.Equals, int64(24))
 			} else {
-				c.Assert(int64(23), gc.Equals, m.Get(i, j).Int64())
+				c.Assert(m.Get(i, j).Int64(), gc.Equals, int64(23))
 			}
 		}
 	}
-	c.Assert(25, gc.Equals, n)
+	c.Assert(n, gc.Equals, 25)
 }
 
 func (s *MatrixSuite) TestSwapRows(c *gc.C) {
@@ -59,8 +59,8 @@ func (s *MatrixSuite) TestSwapRows(c *gc.C) {
 		m.cells[i].Set(Zi(p, i))
 	}
 	m.swapRows(0, 1)
-	c.Assert(int64(0), gc.Equals, m.Get(0, 1).Int64())
-	c.Assert(int64(3), gc.Equals, m.Get(0, 0).Int64())
+	c.Assert(m.Get(0, 1).Int64(), gc.Equals, int64(0))
+	c.Assert(m.Get(0, 0).Int64(), gc.Equals, int64(3))
 }
 
 func (s *MatrixSuite) TestScalarMult(c *gc.C) {
@@ -70,9 +70,9 @@ func (s *MatrixSuite) TestScalarMult(c *gc.C) {
 		m.Set(col, 0, Zi(p, col))
 	}
 	m.scmultRow(0, 0, Zi(p, 2))
-	c.Assert(int64(0), gc.Equals, m.Get(0, 0).Int64())
-	c.Assert(int64(2), gc.Equals, m.Get(1, 0).Int64())
-	c.Assert(int64(4), gc.Equals, m.Get(2, 0).Int64())
+	c.Assert(m.Get(0, 0).Int64(), gc.Equals, int64(0))
+	c.Assert(m.Get(1, 0).Int64(), gc.Equals, int64(2))
+	c.Assert(m.Get(2, 0).Int64(), gc.Equals, int64(4))
 }
 
 func assertEqualMatrix(c *gc.C, m0 *Matrix, m1 *Matrix) {

--- a/src/hockeypuck/conflux/poly_test.go
+++ b/src/hockeypuck/conflux/poly_test.go
@@ -36,19 +36,19 @@ func (s *PolySuite) TestPolyDegree(c *gc.C) {
 	p := big.NewInt(int64(65537))
 	zero := Z(p)
 	poly := NewPoly(Zi(p, 4), Zi(p, 3), Zi(p, 2))
-	c.Assert(2, gc.Equals, poly.Degree())
+	c.Assert(poly.Degree(), gc.Equals, 2)
 	poly = NewPoly(zero, zero, zero, zero, zero, zero, zero, zero)
-	c.Assert(0, gc.Equals, poly.Degree())
+	c.Assert(poly.Degree(), gc.Equals, 0)
 	poly = NewPoly(zero, zero, zero, zero, zero, zero, zero, Zi(p, 1))
-	c.Assert(7, gc.Equals, poly.Degree())
+	c.Assert(poly.Degree(), gc.Equals, 7)
 	poly = NewPoly(zero, zero, zero, zero, zero, zero, zero, Zi(p, 1), zero, zero)
-	c.Assert(7, gc.Equals, poly.Degree())
+	c.Assert(poly.Degree(), gc.Equals, 7)
 }
 
 func (s *PolySuite) TestPolyFmt(c *gc.C) {
 	p := big.NewInt(int64(65537))
 	poly := NewPoly(Zi(p, 4), Zi(p, 3), Zi(p, 2))
-	c.Assert("2z^2 + 3z^1 + 4", gc.Equals, poly.String())
+	c.Assert(poly.String(), gc.Equals, "2z^2 + 3z^1 + 4")
 }
 
 func (s *PolySuite) TestPolyEval(c *gc.C) {
@@ -58,15 +58,15 @@ func (s *PolySuite) TestPolyEval(c *gc.C) {
 	// Constant
 	poly = NewPoly(Zi(p, 5))
 	z = poly.Eval(Zi(p, 8))
-	c.Assert(int64(5), gc.Equals, z.Int64())
+	c.Assert(z.Int64(), gc.Equals, int64(5))
 	// Linear
 	poly = NewPoly(Zi(p, 5), Zi(p, 3))
 	z = poly.Eval(Zi(p, 8))
-	c.Assert(int64(29), gc.Equals, z.Int64())
+	c.Assert(z.Int64(), gc.Equals, int64(29))
 	// Quadratic
 	poly = NewPoly(Zi(p, 5), Zi(p, 3), Zi(p, 2))
 	z = poly.Eval(Zi(p, 8))
-	c.Assert(Zi(p, 157).Int64(), gc.Equals, z.Int64())
+	c.Assert(z.Int64(), gc.Equals, Zi(p, 157).Int64())
 }
 
 func (s *PolySuite) TestPolyMul(c *gc.C) {
@@ -74,10 +74,10 @@ func (s *PolySuite) TestPolyMul(c *gc.C) {
 	x := NewPoly(Zi(p, -6), Zi(p, 11), Zi(p, -6), Zi(p, 1))
 	y := NewPoly(Zi(p, 2), Zi(p, 1))
 	z := NewPolyP(p).Mul(x, y)
-	c.Assert(5, gc.Equals, len(z.coeff))
+	c.Assert(len(z.coeff), gc.Equals, 5)
 	c.Logf("z=%v", z)
 	for i, v := range []int{85, 16, 96, 93, 1} {
-		c.Assert(Zi(p, v).String(), gc.Equals, z.coeff[i].String())
+		c.Assert(z.coeff[i].String(), gc.Equals, Zi(p, v).String())
 	}
 }
 
@@ -87,24 +87,24 @@ func (s *PolySuite) TestPolyAdd(c *gc.C) {
 	x := NewPoly(Zi(p, 1), Zi(p, 1))
 	y := NewPoly(Zi(p, 2), Zi(p, 1))
 	z := NewPolyP(p).Add(x, y)
-	c.Assert(1, gc.Equals, z.degree)
-	c.Assert(int64(3), gc.Equals, z.coeff[0].Int64())
-	c.Assert(int64(2), gc.Equals, z.coeff[1].Int64())
+	c.Assert(z.degree, gc.Equals, 1)
+	c.Assert(z.coeff[0].Int64(), gc.Equals, int64(3))
+	c.Assert(z.coeff[1].Int64(), gc.Equals, int64(2))
 	// (2x+3) - (x+2) = (x+1)
 	x = NewPoly(Zi(p, 3), Zi(p, 2))
 	y = NewPoly(Zi(p, 2), Zi(p, 1))
 	z = NewPolyP(p).Sub(x, y)
-	c.Assert(1, gc.Equals, z.degree)
-	c.Assert(int64(1), gc.Equals, z.coeff[0].Int64())
-	c.Assert(int64(1), gc.Equals, z.coeff[1].Int64())
+	c.Assert(z.degree, gc.Equals, 1)
+	c.Assert(z.coeff[0].Int64(), gc.Equals, int64(1))
+	c.Assert(z.coeff[1].Int64(), gc.Equals, int64(1))
 	// (x+1) - (x^2+2x+1) = (-x^2 - x)
 	x = NewPoly(Zi(p, 1), Zi(p, 1))
 	y = NewPoly(Zi(p, 1), Zi(p, 2), Zi(p, 1))
 	z = NewPolyP(p).Sub(x, y)
-	c.Assert(2, gc.Equals, z.degree)
-	c.Assert(int64(0), gc.Equals, z.coeff[0].Int64())
-	c.Assert(Zi(p, -1).Int64(), gc.Equals, z.coeff[1].Int64())
-	c.Assert(Zi(p, -1).Int64(), gc.Equals, z.coeff[2].Int64())
+	c.Assert(z.degree, gc.Equals, 2)
+	c.Assert(z.coeff[0].Int64(), gc.Equals, int64(0))
+	c.Assert(z.coeff[1].Int64(), gc.Equals, Zi(p, -1).Int64())
+	c.Assert(z.coeff[2].Int64(), gc.Equals, Zi(p, -1).Int64())
 }
 
 func (s *PolySuite) TestPolyDivmod(c *gc.C) {
@@ -114,12 +114,12 @@ func (s *PolySuite) TestPolyDivmod(c *gc.C) {
 	y := NewPoly(Zi(p, 1), Zi(p, 1))
 	q, r, err := PolyDivmod(x, y)
 	c.Logf("q=(%v) r=(%v) err=(%v)", q, r, err)
-	c.Assert(1, gc.Equals, q.degree)
-	c.Assert(int64(1), gc.Equals, q.coeff[0].Int64())
-	c.Assert(int64(1), gc.Equals, q.coeff[1].Int64())
-	c.Assert(2, gc.Equals, len(q.coeff))
+	c.Assert(q.degree, gc.Equals, 1)
+	c.Assert(q.coeff[0].Int64(), gc.Equals, int64(1))
+	c.Assert(q.coeff[1].Int64(), gc.Equals, int64(1))
+	c.Assert(len(q.coeff), gc.Equals, 2)
 	c.Assert(err, gc.IsNil, gc.Commentf("%v", err))
-	c.Assert(0, gc.Equals, r.degree)
+	c.Assert(r.degree, gc.Equals, 0)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -130,8 +130,8 @@ func (s *PolySuite) TestGcd(c *gc.C) {
 	r, err := PolyGcd(x, y)
 	c.Assert(err, gc.IsNil)
 	c.Logf("r=(%v)", r)
-	c.Assert(1, gc.Equals, r.degree)
-	c.Assert(int64(1), gc.Equals, r.coeff[0].Int64())
-	c.Assert(int64(1), gc.Equals, r.coeff[1].Int64())
-	c.Assert(2, gc.Equals, len(r.coeff))
+	c.Assert(r.degree, gc.Equals, 1)
+	c.Assert(r.coeff[0].Int64(), gc.Equals, int64(1))
+	c.Assert(r.coeff[1].Int64(), gc.Equals, int64(1))
+	c.Assert(len(r.coeff), gc.Equals, 2)
 }

--- a/src/hockeypuck/conflux/recon/testing/run_splits.go
+++ b/src/hockeypuck/conflux/recon/testing/run_splits.go
@@ -62,7 +62,7 @@ func (s *ReconSuite) TestSplits85(c *gc.C) {
 	}
 	root, err := ptree.Root()
 	c.Assert(err, gc.IsNil)
-	c.Assert(85, gc.Equals, root.Size())
+	c.Assert(root.Size(), gc.Equals, 85)
 	for i, child := range recon.MustChildren(root) {
 		c.Log("child#", i, ":", child.Key())
 	}
@@ -77,16 +77,16 @@ func (s *ReconSuite) TestSplits85(c *gc.C) {
 
 	node, err := lookupNode("00", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(17, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 17)
 	node, err = lookupNode("01", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(19, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 19)
 	node, err = lookupNode("10", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(21, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 21)
 	node, err = lookupNode("11", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(28, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 28)
 }
 
 func (s *ReconSuite) RunSplits15k(c *gc.C) {
@@ -100,14 +100,14 @@ func (s *ReconSuite) RunSplits15k(c *gc.C) {
 	}
 	root, err := ptree.Root()
 	c.Assert(err, gc.IsNil)
-	c.Assert(15000, gc.Equals, root.Size())
+	c.Assert(root.Size(), gc.Equals, 15000)
 	node, err := lookupNode("11", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(15000, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 15000)
 	node, err = lookupNode("11011011", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(12995, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 12995)
 	node, err = lookupNode("1101101011", root)
 	c.Assert(err, gc.IsNil)
-	c.Assert(2005, gc.Equals, node.Size())
+	c.Assert(node.Size(), gc.Equals, 2005)
 }

--- a/src/hockeypuck/conflux/zp_test.go
+++ b/src/hockeypuck/conflux/zp_test.go
@@ -47,18 +47,18 @@ func zp7(n int) *Zp {
 func (s *ZpSuite) TestAdd(c *gc.C) {
 	a := zp5(1)
 	b := zp5(3)
-	c.Assert(0, gc.Equals, zp5(4).Cmp(a.Add(a, b)))
+	c.Assert(zp5(4).Cmp(a.Add(a, b)), gc.Equals, 0)
 }
 
 func (s *ZpSuite) TestAddWrap(c *gc.C) {
 	a := zp5(1)
 	b := zp5(9)
-	c.Assert(0, gc.Equals, zp5(0).Cmp(a.Add(a, b)))
+	c.Assert(zp5(0).Cmp(a.Add(a, b)), gc.Equals, 0)
 }
 
 func (s *ZpSuite) TestMinusOne(c *gc.C) {
 	a := Zi(p(65537), -1)
-	c.Assert(int64(65536), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(65536))
 }
 
 func (s *ZpSuite) TestMul(c *gc.C) {
@@ -66,18 +66,18 @@ func (s *ZpSuite) TestMul(c *gc.C) {
 	a := zp5(4)
 	b := zp5(3)
 	a.Mul(a, b)
-	c.Assert(int64(2), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(2))
 	// 4x4x3
 	a = zp5(4)
 	b = zp5(3)
 	a.Mul(a, a)
 	a.Mul(a, b)
-	c.Assert(int64(3), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(3))
 	// 16x16
 	a = zp5(4)
 	a.Mul(a, a) // 4x4
 	a.Mul(a, a) // 16x16
-	c.Assert(int64(1), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(1))
 }
 
 func (s *ZpSuite) TestDiv(c *gc.C) {
@@ -85,12 +85,12 @@ func (s *ZpSuite) TestDiv(c *gc.C) {
 	a := zp5(1)
 	b := zp5(2)
 	q := Z(p(5)).Div(a, b)
-	c.Assert(int64(3), gc.Equals, q.Int64())
+	c.Assert(q.Int64(), gc.Equals, int64(3))
 	// in Z(5), 1 / 3 = 2 because 3 * 2 = 1.
 	a = zp5(1)
 	b = zp5(3)
 	q = Z(p(5)).Div(a, b)
-	c.Assert(int64(2), gc.Equals, q.Int64())
+	c.Assert(q.Int64(), gc.Equals, int64(2))
 }
 
 func (s *ZpSuite) TestMismatchedP(c *gc.C) {
@@ -107,34 +107,34 @@ func (s *ZpSuite) TestMismatchedP(c *gc.C) {
 func (s *ZpSuite) TestNeg(c *gc.C) {
 	a := zp5(2)
 	a.Neg()
-	c.Assert(int64(3), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(3))
 	a = zp5(0)
 	a.Neg()
-	c.Assert(int64(0), gc.Equals, a.Int64())
+	c.Assert(a.Int64(), gc.Equals, int64(0))
 }
 
 func (s *ZpSuite) TestSub(c *gc.C) {
 	az := zp5(4)
 	bz := zp5(3)
 	cz := Z(az.P()).Sub(az, bz)
-	c.Assert(int64(4), gc.Equals, az.Int64())
-	c.Assert(int64(3), gc.Equals, bz.Int64())
-	c.Assert(int64(1), gc.Equals, cz.Int64())
+	c.Assert(az.Int64(), gc.Equals, int64(4))
+	c.Assert(bz.Int64(), gc.Equals, int64(3))
+	c.Assert(cz.Int64(), gc.Equals, int64(1))
 }
 
 func (s *ZpSuite) TestSubRoll(c *gc.C) {
 	az := zp5(1)
 	bz := zp5(3)
 	cz := Z(az.P()).Sub(az, bz)
-	c.Assert(int64(1), gc.Equals, az.Int64())
-	c.Assert(int64(3), gc.Equals, bz.Int64())
-	c.Assert(int64(3), gc.Equals, cz.Int64()) // -2 == 3
+	c.Assert(az.Int64(), gc.Equals, int64(1))
+	c.Assert(bz.Int64(), gc.Equals, int64(3))
+	c.Assert(cz.Int64(), gc.Equals, int64(3)) // -2 == 3
 	az = zp5(1)
 	bz = zp5(4)
 	cz = az.Copy().Sub(az, bz)
-	c.Assert(int64(1), gc.Equals, az.Int64())
-	c.Assert(int64(4), gc.Equals, bz.Int64())
-	c.Assert(int64(2), gc.Equals, cz.Int64()) // -3 == 2
+	c.Assert(az.Int64(), gc.Equals, int64(1))
+	c.Assert(bz.Int64(), gc.Equals, int64(4))
+	c.Assert(cz.Int64(), gc.Equals, int64(2)) // -3 == 2
 }
 
 func (s *ZpSuite) TestZSet(c *gc.C) {
@@ -186,9 +186,9 @@ func (s *ZpSuite) TestZSetDiffEmpty(c *gc.C) {
 func (s *ZpSuite) TestByteOrder(c *gc.C) {
 	z := Zi(P_SKS, 65536)
 	c.Logf("%x", z.Bytes())
-	c.Assert(byte(0), gc.Equals, z.Bytes()[0])
-	c.Assert(byte(0), gc.Equals, z.Bytes()[1])
-	c.Assert(byte(1), gc.Equals, z.Bytes()[2])
+	c.Assert(z.Bytes()[0], gc.Equals, byte(0))
+	c.Assert(z.Bytes()[1], gc.Equals, byte(0))
+	c.Assert(z.Bytes()[2], gc.Equals, byte(1))
 }
 
 func (s *ZpSuite) TestByteRtt(c *gc.C) {

--- a/src/hockeypuck/go.mod
+++ b/src/hockeypuck/go.mod
@@ -32,13 +32,14 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.13.0 // indirect
+	github.com/prometheus/procfs v0.1.3 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/stvp/go-udp-testing v0.0.0-20171104055251-c4434f09ec13
 	github.com/syndtr/goleveldb v0.0.0-20200815110645-5c35d600f0ca
 	github.com/tobi/airbrake-go v0.0.0-20151005181455-a3cdd910a3ff
 	github.com/urfave/negroni v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
-	golang.org/x/sys v0.0.0-20200821140526-fda516888d29 // indirect
+	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/basen.v1 v1.0.0-20150613233243-308119dd1d4c
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f

--- a/src/hockeypuck/go.sum
+++ b/src/hockeypuck/go.sum
@@ -420,6 +420,8 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29 h1:mNuhGagCf3lDDm5C0376C/sxh6V7fy9WbdEu/YDNA04=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/src/hockeypuck/hkp/requests.go
+++ b/src/hockeypuck/hkp/requests.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -102,6 +103,11 @@ func ParseLookup(req *http.Request) (*Lookup, error) {
 		l.Search = req.Form.Get("search")
 		if l.Search == "" {
 			return nil, errors.Errorf("missing required parameter: search")
+		}
+		if l.Op == OperationIndex {
+			// If it looks like a fingerprint or long-ID, normalise to "0x" format
+			fingerprintRegex := regexp.MustCompile(`^([a-fA-F0-9]{16}|[a-fA-F0-9]{32}|[a-fA-F0-9]{40})$`)
+			l.Search = fingerprintRegex.ReplaceAllString(l.Search, "0x$1")
 		}
 	}
 

--- a/src/hockeypuck/hkp/requests_test.go
+++ b/src/hockeypuck/hkp/requests_test.go
@@ -67,6 +67,45 @@ func (s *RequestsSuite) TestGetFp(c *gc.C) {
 	c.Assert(lookup.Exact, gc.Equals, true)
 }
 
+func (s *RequestsSuite) TestGetBareFp(c *gc.C) {
+	// bare v4-fp search (without 0x) - 40 nybbles; should get modified
+	testUrl, err := url.Parse("/pks/lookup?op=get&search=decafbaddecafbaddecafbaddecafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
+	c.Assert(err, gc.IsNil)
+	req := &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err := ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert("0xdecafbaddecafbaddecafbaddecafbaddecafbad", gc.Equals, lookup.Search)
+	// bare v3-fp search (without 0x) - 32 nybbles; should get modified
+	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbaddecafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert("0xdecafbaddecafbaddecafbaddecafbad", gc.Equals, lookup.Search)
+	// bare long-id search (without 0x) - 16 nybbles; should get modified
+	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert("0xdecafbaddecafbad", gc.Equals, lookup.Search)
+	// bare short-id search (without 0x) - 8 nybbles; should NOT get modified
+	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbad&options=mr,nm&fingerprint=on&exact=on")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert("decafbad", gc.Equals, lookup.Search)
+}
+
 func (s *RequestsSuite) TestIndex(c *gc.C) {
 	// op=index
 	testUrl, err := url.Parse("/pks/lookup?op=index&search=sharin") // as in, foo

--- a/src/hockeypuck/hkp/requests_test.go
+++ b/src/hockeypuck/hkp/requests_test.go
@@ -43,8 +43,8 @@ func (s *RequestsSuite) TestGetKeyword(c *gc.C) {
 		URL:    testUrl}
 	lookup, err := ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert(OperationGet, gc.Equals, lookup.Op)
-	c.Assert("alice", gc.Equals, lookup.Search)
+	c.Assert(lookup.Op, gc.Equals, OperationGet)
+	c.Assert(lookup.Search, gc.Equals, "alice")
 	c.Assert(lookup.Options, gc.HasLen, 0)
 	c.Assert(lookup.Fingerprint, gc.Equals, false)
 	c.Assert(lookup.Exact, gc.Equals, false)
@@ -59,8 +59,8 @@ func (s *RequestsSuite) TestGetFp(c *gc.C) {
 		URL:    testUrl}
 	lookup, err := ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert(OperationGet, gc.Equals, lookup.Op)
-	c.Assert("0xdecafbad", gc.Equals, lookup.Search)
+	c.Assert(lookup.Op, gc.Equals, OperationGet)
+	c.Assert(lookup.Search, gc.Equals, "0xdecafbad")
 	c.Assert(lookup.Options[OptionMachineReadable], gc.Equals, true)
 	c.Assert(lookup.Options[OptionNotModifiable], gc.Equals, true)
 	c.Assert(lookup.Fingerprint, gc.Equals, true)
@@ -76,7 +76,7 @@ func (s *RequestsSuite) TestGetBareFp(c *gc.C) {
 		URL:    testUrl}
 	lookup, err := ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert("0xdecafbaddecafbaddecafbaddecafbaddecafbad", gc.Equals, lookup.Search)
+	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbaddecafbad")
 	// bare v3-fp search (without 0x) - 32 nybbles; should get modified
 	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbaddecafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
 	c.Assert(err, gc.IsNil)
@@ -85,7 +85,7 @@ func (s *RequestsSuite) TestGetBareFp(c *gc.C) {
 		URL:    testUrl}
 	lookup, err = ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert("0xdecafbaddecafbaddecafbaddecafbad", gc.Equals, lookup.Search)
+	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbad")
 	// bare long-id search (without 0x) - 16 nybbles; should get modified
 	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
 	c.Assert(err, gc.IsNil)
@@ -103,7 +103,7 @@ func (s *RequestsSuite) TestGetBareFp(c *gc.C) {
 		URL:    testUrl}
 	lookup, err = ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert("decafbad", gc.Equals, lookup.Search)
+	c.Assert(lookup.Search, gc.Equals, "decafbad")
 }
 
 func (s *RequestsSuite) TestIndex(c *gc.C) {
@@ -127,7 +127,7 @@ func (s *RequestsSuite) TestVindex(c *gc.C) {
 		URL:    testUrl}
 	lookup, err := ParseLookup(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert(OperationVIndex, gc.Equals, lookup.Op)
+	c.Assert(lookup.Op, gc.Equals, OperationVIndex)
 }
 
 func (s *RequestsSuite) TestMissingSearch(c *gc.C) {
@@ -164,7 +164,7 @@ func (s *RequestsSuite) TestAdd(c *gc.C) {
 	req.PostForm = url.Values(postData)
 	add, err := ParseAdd(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert("sus llaves aqui", gc.Equals, add.Keytext)
+	c.Assert(add.Keytext, gc.Equals, "sus llaves aqui")
 	c.Assert(add.Options, gc.HasLen, 0)
 }
 
@@ -179,7 +179,7 @@ func (s *RequestsSuite) TestAddOptions(c *gc.C) {
 	req.PostForm = url.Values(postData)
 	add, err := ParseAdd(req)
 	c.Assert(err, gc.IsNil)
-	c.Assert("sus llaves estan aqui", gc.Equals, add.Keytext)
+	c.Assert(add.Keytext, gc.Equals, "sus llaves estan aqui")
 	c.Assert(add.Options[OptionMachineReadable], gc.Equals, true)
 	c.Assert(add.Options[OptionNotModifiable], gc.Equals, false)
 }

--- a/src/hockeypuck/hkp/requests_test.go
+++ b/src/hockeypuck/hkp/requests_test.go
@@ -67,45 +67,6 @@ func (s *RequestsSuite) TestGetFp(c *gc.C) {
 	c.Assert(lookup.Exact, gc.Equals, true)
 }
 
-func (s *RequestsSuite) TestGetBareFp(c *gc.C) {
-	// bare v4-fp search (without 0x) - 40 nybbles; should get modified
-	testUrl, err := url.Parse("/pks/lookup?op=get&search=decafbaddecafbaddecafbaddecafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
-	c.Assert(err, gc.IsNil)
-	req := &http.Request{
-		Method: "GET",
-		URL:    testUrl}
-	lookup, err := ParseLookup(req)
-	c.Assert(err, gc.IsNil)
-	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbaddecafbad")
-	// bare v3-fp search (without 0x) - 32 nybbles; should get modified
-	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbaddecafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
-	c.Assert(err, gc.IsNil)
-	req = &http.Request{
-		Method: "GET",
-		URL:    testUrl}
-	lookup, err = ParseLookup(req)
-	c.Assert(err, gc.IsNil)
-	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbad")
-	// bare long-id search (without 0x) - 16 nybbles; should get modified
-	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbaddecafbad&options=mr,nm&fingerprint=on&exact=on")
-	c.Assert(err, gc.IsNil)
-	req = &http.Request{
-		Method: "GET",
-		URL:    testUrl}
-	lookup, err = ParseLookup(req)
-	c.Assert(err, gc.IsNil)
-	c.Assert("0xdecafbaddecafbad", gc.Equals, lookup.Search)
-	// bare short-id search (without 0x) - 8 nybbles; should NOT get modified
-	testUrl, err = url.Parse("/pks/lookup?op=get&search=decafbad&options=mr,nm&fingerprint=on&exact=on")
-	c.Assert(err, gc.IsNil)
-	req = &http.Request{
-		Method: "GET",
-		URL:    testUrl}
-	lookup, err = ParseLookup(req)
-	c.Assert(err, gc.IsNil)
-	c.Assert(lookup.Search, gc.Equals, "decafbad")
-}
-
 func (s *RequestsSuite) TestIndex(c *gc.C) {
 	// op=index
 	testUrl, err := url.Parse("/pks/lookup?op=index&search=sharin") // as in, foo
@@ -116,6 +77,45 @@ func (s *RequestsSuite) TestIndex(c *gc.C) {
 	lookup, err := ParseLookup(req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(lookup.Op, gc.Equals, OperationIndex)
+}
+
+func (s *RequestsSuite) TestIndexBareFp(c *gc.C) {
+	// bare v4-fp search (without 0x) - 40 nybbles; should get modified
+	testUrl, err := url.Parse("/pks/lookup?op=index&search=decafbaddecafbaddecafbaddecafbaddecafbad")
+	c.Assert(err, gc.IsNil)
+	req := &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err := ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbaddecafbad")
+	// bare v3-fp search (without 0x) - 32 nybbles; should get modified
+	testUrl, err = url.Parse("/pks/lookup?op=index&search=decafbaddecafbaddecafbaddecafbad")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(lookup.Search, gc.Equals, "0xdecafbaddecafbaddecafbaddecafbad")
+	// bare long-id search (without 0x) - 16 nybbles; should get modified
+	testUrl, err = url.Parse("/pks/lookup?op=index&search=decafbaddecafbad")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert("0xdecafbaddecafbad", gc.Equals, lookup.Search)
+	// bare short-id search (without 0x) - 8 nybbles; should NOT get modified
+	testUrl, err = url.Parse("/pks/lookup?op=index&search=decafbad")
+	c.Assert(err, gc.IsNil)
+	req = &http.Request{
+		Method: "GET",
+		URL:    testUrl}
+	lookup, err = ParseLookup(req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(lookup.Search, gc.Equals, "decafbad")
 }
 
 func (s *RequestsSuite) TestVindex(c *gc.C) {

--- a/src/hockeypuck/openpgp/resolve_test.go
+++ b/src/hockeypuck/openpgp/resolve_test.go
@@ -201,7 +201,7 @@ func (s *ResolveSuite) TestV3NoUidSig(c *gc.C) {
 		h.Write(opkt.Contents)
 	}
 	md5 := hex.EncodeToString(h.Sum(nil))
-	c.Assert("0005127a8b7da8c32998d7e81dc92540", gc.Equals, md5)
+	c.Assert(md5, gc.Equals, "0005127a8b7da8c32998d7e81dc92540")
 }
 
 func (s *ResolveSuite) TestMergeAddSig(c *gc.C) {

--- a/src/hockeypuck/openpgp/types_test.go
+++ b/src/hockeypuck/openpgp/types_test.go
@@ -49,10 +49,10 @@ func (s *TypesSuite) TestVisitor(c *gc.C) {
 			c.Fatalf("unexpected node type: %+v", p)
 		}
 	}
-	c.Assert(1, gc.Equals, npub)
-	c.Assert(1, gc.Equals, nuid)
-	c.Assert(1, gc.Equals, nsub)
-	c.Assert(2, gc.Equals, nsig)
+	c.Assert(npub, gc.Equals, 1)
+	c.Assert(nuid, gc.Equals, 1)
+	c.Assert(nsub, gc.Equals, 1)
+	c.Assert(nsig, gc.Equals, 2)
 }
 
 func (s *TypesSuite) TestIterOpaque(c *gc.C) {
@@ -68,12 +68,12 @@ func (s *TypesSuite) TestIterOpaque(c *gc.C) {
 		hits[node.packet().Tag]++
 	}
 	c.Log(hits)
-	c.Assert(2, gc.Equals, hits[2 /*P.PacketTypeSignature*/])
-	c.Assert(1, gc.Equals, hits[6 /*P.PacketTypePublicKey*/])
-	c.Assert(1, gc.Equals, hits[13 /*P.PacketTypeUserId*/])
-	c.Assert(1, gc.Equals, len(key.UserIDs))
-	c.Assert(1, gc.Equals, len(key.UserIDs[0].Signatures))
-	c.Assert(1, gc.Equals, hits[14 /*P.PacketTypePublicSubKey*/])
-	c.Assert(1, gc.Equals, len(key.SubKeys[0].Signatures))
-	c.Assert(4, gc.Equals, len(hits))
+	c.Assert(hits[2 /*P.PacketTypeSignature*/], gc.Equals, 2)
+	c.Assert(hits[6 /*P.PacketTypePublicKey*/], gc.Equals, 1)
+	c.Assert(hits[13 /*P.PacketTypeUserId*/], gc.Equals, 1)
+	c.Assert(len(key.UserIDs), gc.Equals, 1)
+	c.Assert(len(key.UserIDs[0].Signatures), gc.Equals, 1)
+	c.Assert(hits[14 /*P.PacketTypePublicSubKey*/], gc.Equals, 1)
+	c.Assert(len(key.SubKeys[0].Signatures), gc.Equals, 1)
+	c.Assert(len(hits), gc.Equals, 4)
 }


### PR DESCRIPTION
Closes #169 
Also improved some of the tests:

* make had been consuming the stdout of `go fmt` so the error was uninformative
* c.Assert() expects its first argument to be the obtained string and the third the expected string. If these are reversed the error messages are confusing.
* [EDIT] x/sys required an update to run tests on my devel macbook

Currently deployed on https://fi.pgpkeys.eu