### PR TITLE
Limit the output of the HashQuery response

### DIFF
--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -247,7 +247,11 @@ func (h *Handler) HashQuery(w http.ResponseWriter, r *http.Request, _ httprouter
 	w.Header().Set("Content-Type", "pgp/keys")
 
 	// Write the number of keys
-	recon.WriteInt(w, len(result))
+	if err := recon.WriteInt(w, len(result)); err != nil {
+		// log the error
+		log.Errorf("error writing number of keys, peer connection lost: %v", err)
+		return
+	}
 	for _, key := range result {
 		// Write each key in binary packet format, prefixed with length
 		err = writeHashqueryKey(w, key)

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -158,6 +158,9 @@ func NewServer(settings *Settings) (*Server, error) {
 	if settings.StatsTemplate != "" {
 		options = append(options, hkp.StatsTemplate(settings.StatsTemplate))
 	}
+	if settings.MaxResponseLen != 0 {
+		options = append(options, hkp.MaxResponseLen(settings.MaxResponseLen))
+	}
 	h, err := hkp.NewHandler(s.st, options...)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -48,6 +48,10 @@ type HKPConfig struct {
 	Queries queryConfig `toml:"queries"`
 }
 
+const (
+	DefaultMaxResponseLen = 268435456
+)
+
 type queryConfig struct {
 	// Only respond with verified self-signed key material in queries
 	SelfSignedOnly bool `toml:"selfSignedOnly"`
@@ -186,6 +190,8 @@ type Settings struct {
 	Version  string `toml:"version"`
 
 	SksCompat bool `toml:"sksCompat"`
+
+	MaxResponseLen int `toml:"maxResponseLen"`
 }
 
 const (
@@ -208,12 +214,13 @@ func DefaultSettings() Settings {
 		HKP: HKPConfig{
 			Bind: DefaultHKPBind,
 		},
-		Metrics:   metricsSettings,
-		OpenPGP:   DefaultOpenPGP(),
-		LogLevel:  DefaultLogLevel,
-		Software:  "Hockeypuck",
-		Version:   "~unreleased",
-		SksCompat: false,
+		Metrics:        metricsSettings,
+		OpenPGP:        DefaultOpenPGP(),
+		LogLevel:       DefaultLogLevel,
+		Software:       "Hockeypuck",
+		Version:        "~unreleased",
+		SksCompat:      false,
+		MaxResponseLen: DefaultMaxResponseLen,
 	}
 }
 


### PR DESCRIPTION
Trying to reduce the OOM kills that we get on our servers we would like to limit the number of keys returned based on memory usage. After we reach a certain threshold we would truncate the response and the rest of the requested keys can be requested on subsequent queries.

In our investigation, we discovered that POST requests to hashquery can result in multiple GB of memory being used to build a response and we aim to add a maximum response value configurable through a MaxResponseLen setting.
