### PR TITLE
docker-compose: Allow using a non-default CA

### DIFF
--- a/contrib/docker-compose/standalone/README.md
+++ b/contrib/docker-compose/standalone/README.md
@@ -23,6 +23,7 @@ At minimum, docker and docker-compose (v1.5 or later) must be installed in advan
 * Customize the settings in `.env` to your liking.
    Set EMAIL and FINGERPRINT to the contact email and associated PGP fingerprint of the site admin.
    Set FQDN and (optionally) ALIAS_FQDNS to the primary (and other) DNS name(s) of your server.
+   (Optional) Set ACME_SERVER to your internal CA if not using Let's Encrypt.
 * Generate hockeypuck and nginx configuration from your site settings with
    `./mkconfig.bash`.
 * Build hockeypuck by incanting `docker-compose build`.

--- a/contrib/docker-compose/standalone/init-letsencrypt.bash
+++ b/contrib/docker-compose/standalone/init-letsencrypt.bash
@@ -82,8 +82,12 @@ esac
 # Enable staging mode if needed
 if [ "${CERTBOT_STAGING:-0}" != "0" ]; then staging_arg="--staging"; else staging_arg=""; fi
 
+# Use a non-default CA server if specified
+if [ -n "${ACME_SERVER}" ]; then server_arg="--server ${ACME_SERVER}"; else server_arg=""; fi
+
 docker-compose run --rm --entrypoint "\
   certbot certonly --webroot -w /etc/nginx/html \
+    $server_arg \
     $staging_arg \
     $email_arg \
     $domain_args \

--- a/contrib/docker-compose/standalone/mksite.bash
+++ b/contrib/docker-compose/standalone/mksite.bash
@@ -20,6 +20,8 @@ ALIAS_FQDNS=""
 EMAIL=admin@example.com
 # PGP encryption key for the above email address
 FINGERPRINT=0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
+# ACME Directory Resource URI (use Let's Encrypt if empty)
+ACME_SERVER=
 
 ###########################################################
 # You normally won't need to change anything below here


### PR DESCRIPTION
The SSL certificate for HTTPS is managed by certbot. The default
CA is Let's Encrypt, but some environments may not use it
(e.g. because they are not reachable from the public internet).

Thankfully, certbot implements a --server option to override the
default. Add support for this option to init-letsencrypt.bash and
add the ACME_SERVER variable to settings.