### PR TITLE
Remove lint from default build workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=builder:root src /hockeypuck/src
 ENV GOPATH=/hockeypuck
 USER builder
 WORKDIR /hockeypuck
-RUN make lint test test-postgresql
+RUN make test test-postgresql
 COPY --chown=builder:root .git /hockeypuck/.git
 RUN make build
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ commands = \
 	hockeypuck-load \
 	hockeypuck-pbuild
 
-all: lint test build
+all: test build
 
 build:
 


### PR DESCRIPTION
The `make lint` stage in the build workflow is causing issues with the gofmt 1.18->1.19 version bump (see #201). We should restrict `make lint` to the github PR workflow, as linting is only of interest to developers.