### PR TITLE
proper error messages for config load fail

### DIFF
--- a/src/hockeypuck/server/cmd/cmd.go
+++ b/src/hockeypuck/server/cmd/cmd.go
@@ -14,7 +14,7 @@ import (
 
 func Die(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%+v", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/src/hockeypuck/server/cmd/hockeypuck-dump/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-dump/main.go
@@ -41,10 +41,12 @@ func main() {
 	if configFile != nil {
 		conf, err := ioutil.ReadFile(*configFile)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 		settings, err = server.ParseSettings(string(conf))
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 	}

--- a/src/hockeypuck/server/cmd/hockeypuck-load/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-load/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -36,10 +37,12 @@ func main() {
 	if configFile != nil {
 		conf, err := ioutil.ReadFile(*configFile)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 		settings, err = server.ParseSettings(string(conf))
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 	}

--- a/src/hockeypuck/server/cmd/hockeypuck-pbuild/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck-pbuild/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -33,10 +34,12 @@ func main() {
 	if configFile != nil {
 		conf, err := ioutil.ReadFile(*configFile)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 		settings, err = server.ParseSettings(string(conf))
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 	}

--- a/src/hockeypuck/server/cmd/hockeypuck/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -34,10 +35,12 @@ func main() {
 	if configFile != nil {
 		conf, err := ioutil.ReadFile(*configFile)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 		settings, err = server.ParseSettings(string(conf))
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing configuration file '%s'.\n", *configFile)
 			cmd.Die(errors.WithStack(err))
 		}
 	}


### PR DESCRIPTION
when any of the fours command is called without -config parameter, the output
is currently:
```
open : no such file or directory
main.main
        /var/lib/hockeypuck/hockeypuck/src/hockeypuck/server/cmd/hockeypuck-pbuild/main.go:36
runtime.main
        /opt/go/1.19/src/runtime/proc.go:250
runtime.goexit
```

which does not say what the error actually is. Except when looking into the code.

Therefore, output additional messages:
if loading the configuration file itself fails
or if parsing the configuration file fails

Now the commands also say:
```
Error loading configuration file ''.
```
That at least gives a hint what the error is about, namely the config file. A default config path would be nice too ;)