### PR TITLE
Always return full fingerprint in mr-index; closes #194

### DIFF
--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -393,6 +393,10 @@ func (h *Handler) index(w http.ResponseWriter, l *Lookup, f IndexFormat) {
 
 	if l.Options[OptionMachineReadable] {
 		f = mrFormat
+		// always return full fingerprints in machine readable [v]index
+		// this works around a known issue in GPGTools
+		// https://gpgtools.tenderapp.com/discussions/problems/121371-cannot-upload-existing-public-keys-to-hockeypuck-key-servers
+		l.Fingerprint = true
 	} else if l.Options[OptionJSON] || f == nil {
 		f = jsonFormat
 	}

--- a/src/hockeypuck/hkp/handler_test.go
+++ b/src/hockeypuck/hkp/handler_test.go
@@ -197,7 +197,7 @@ func (s *HandlerSuite) TestIndexAliceMR(c *gc.C) {
 	c.Assert(res.StatusCode, gc.Equals, http.StatusOK)
 
 	c.Assert(string(doc), gc.Equals, `info:1:1
-pub:361BC1F023E0DCCA:1:2048:1345589945::
+pub:10FE8CF1B483F7525039AA2A361BC1F023E0DCCA:1:2048:1345589945::
 uid:alice <alice@example.com>:1345589945::
 `)
 }


### PR DESCRIPTION
Mitigates https://gpgtools.tenderapp.com/discussions/problems/121371-cannot-upload-existing-public-keys-to-hockeypuck-key-servers