### PR TITLE
Don't purge historical sigs on revocation; closes #197

### DIFF
--- a/src/hockeypuck/openpgp/selfsigs.go
+++ b/src/hockeypuck/openpgp/selfsigs.go
@@ -80,13 +80,6 @@ func (s checkSigExpirationDesc) Swap(i, j int) {
 }
 
 func (s *SelfSigs) resolve() {
-	// Revocations cancel all other certifications
-	if len(s.Revocations) > 0 {
-		s.Certifications = nil
-		s.Expirations = nil
-		s.Primaries = nil
-	}
-
 	// Sort signatures
 	sort.Sort(checkSigCreationAsc(s.Revocations))
 	sort.Sort(checkSigCreationDesc(s.Certifications))


### PR DESCRIPTION
Valid expired self-sigs can still be useful. Discarding them is a client-side decision, not ours.