### PR TITLE
Don't set selfSignedOnly in default config

### DIFF
--- a/contrib/docker-compose/standalone/hockeypuck/etc/hockeypuck.conf.tmpl
+++ b/contrib/docker-compose/standalone/hockeypuck/etc/hockeypuck.conf.tmpl
@@ -11,9 +11,6 @@ contact="${FINGERPRINT}"
 bind=":11371"
 logRequestDetails=false
 
-[hockeypuck.hkp.queries]
-selfSignedOnly=true
-
 # prevent abusively large keys
 [hockeypuck.openpgp]
 maxPacketLength=8192


### PR DESCRIPTION
We shouldn't railroad operators into setting `selfSignedOnly=true` by default without considering the significant change in behaviour that it causes.