### PR TITLE
systemd service file: start after postgres is ready

### DIFF
--- a/debian/hockeypuck.service
+++ b/debian/hockeypuck.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=hockeypuck
-After=network.target
+After=network.target postgresql.service
+Requires=postgresql.service
 
 [Service]
 User=hockeypuck


### PR DESCRIPTION
postgres must be started and ready for hockeypuck, so start hockeypuck after it.
Requires only start postgres with hockeypuck together, without delay, resulting in failing hockeypuck starts

Also changed in the ansible role: https://github.com/sebix/ansible-hockeypuck/commit/cb39e55e9ad868d1f1640670cdd274ec38f373bf