### PR TITLE
Add server vhosts support

### DIFF
--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -241,7 +241,7 @@ func (s statsPeers) Len() int           { return len(s) }
 func (s statsPeers) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s statsPeers) Less(i, j int) bool { return s[i].Name < s[j].Name }
 
-func (s *Server) stats() (interface{}, error) {
+func (s *Server) stats(req *http.Request) (interface{}, error) {
 	sksStats := s.sksPeer.Stats()
 
 	result := &stats{
@@ -270,6 +270,10 @@ func (s *Server) stats() (interface{}, error) {
 		result.Hostname = s.settings.Hostname
 	} else if nodename != "" {
 		result.Hostname = nodename
+	}
+
+	if s.settings.EnableVHosts {
+		result.Hostname = req.Host
 	}
 
 	for k, v := range sksStats.Hourly {

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -187,11 +187,12 @@ type Settings struct {
 
 	Webroot string `toml:"webroot"`
 
-	Contact  string `toml:"contact"`
-	Hostname string `toml:"hostname"`
-	Software string
-	Version  string
-	BuiltAt  string
+	Contact      string `toml:"contact"`
+	Hostname     string `toml:"hostname"`
+	EnableVHosts bool   `toml:"enableVHosts"`
+	Software     string
+	Version      string
+	BuiltAt      string
 
 	MaxResponseLen int `toml:"maxResponseLen"`
 }


### PR DESCRIPTION
We want to let Hockeypuck server pick the request Host header and use it for presenting stats and other information using it. This way we can expose the service via Tor for example.

Closes #231 