### PR TITLE
CHORE: Add ALIAS_FQDNS and CLUSTER_FQDNS variables for Docker shim

### DIFF
--- a/contrib/docker-compose/standalone/docker-compose-shim.yml
+++ b/contrib/docker-compose/standalone/docker-compose-shim.yml
@@ -11,6 +11,8 @@ services:
     restart: always
     init: true
     environment:
+    - ALIAS_FQDNS
+    - CLUSTER_FQDNS
     - FQDN
     - KEYSERVER_HOST_PORT
     - HAP_DHPARAM_FILE=/etc/letsencrypt/ssl-dhparams.pem


### PR DESCRIPTION
We want to be able to configure FQDN aliases for Hockeypuck that HAProxy shim will handle.