### PR TITLE
HOTFIX: Fix if-else logic in 50_fe_http_handler.conf

### DIFF
--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
@@ -27,7 +27,9 @@ frontend fe_http_handler
     .if defined(HAP_BEHIND_CLOUDFLARE)
     .notice "Enabling Cloudflare support"
     http-request set-var(txn.cloudflare) str(ENABLED)
-    .elseif defined(HAP_BEHIND_PROXY)
+    .endif
+
+    .if defined(HAP_BEHIND_PROXY)
     .notice "Enabling reverse proxy support"
     http-request set-var(txn.cdn) str(ENABLED)
     .endif


### PR DESCRIPTION
It looks like that HAProxy documentation is misleading and .if-.elseif-.endif is not a correct construct. This change splits it into two separate .if-.endif