### PR TITLE
Specify working directory for systemd unit

### DIFF
--- a/debian/hockeypuck.service
+++ b/debian/hockeypuck.service
@@ -8,6 +8,7 @@ User=hockeypuck
 Group=hockeypuck
 LimitNOFILE=49152
 Environment=HOME=/var/lib/hockeypuck
+WorkingDirectory=/var/lib/hockeypuck
 ExecStart=/usr/bin/hockeypuck -config /etc/hockeypuck/hockeypuck.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=on-failure


### PR DESCRIPTION
The working directory in the systemd unit has to be specified (at least under Debian 12). Otherwise the location where the `recon.db` folder is not created under `/var/lib/hockeypuck`. The daemon refuses to start then, because the `recon.db` folder cannot be created.