### PR TITLE
CHORE: Rename custom env templating function to osenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ In order to release a new version of hockeypuck:
 Where `x.y.z` is the appropriate version number.
 This will upload the debian source package to the Launchpad PPA for building.
 
+# Configuration file templating and format
+
+The configuration file supports templating using the Go text/template package with Sprig extensions.
+The template is rendered before the configuration file is parsed, so the configuration file can contain
+environment variables as well.
+
+For example, setting the database configuration to use environment variables:
+
+```toml
+[hockeypuck.openpgp.db]
+driver="postgres-jsonb"
+dsn="database=hkp host=postgres user={{ .POSTGRES_USER }} password={{ .POSTGRES_PASSWORD }} port=5432 sslmode=disable"
+```
+
+You can also use the `osenv` custom function to read environment variables by prefix:
+
+```toml
+{{ range $key, $value := osenv "HKP_" }}
+{{ $key }}={{ $value }}
+{{ end }}
+```
+
 # About
 
 Copyright 2023, The Hockeypuck Developers; see CONTRIBUTORS and LICENSE for details.

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -277,12 +277,12 @@ func ParseSettings(data string) (*Settings, error) {
 func envFuncMap() template.FuncMap {
 	return template.FuncMap(
 		map[string]interface{}{
-			"env": func(key string) map[string]string {
+			"osenv": func(prefix string) map[string]string {
 				env := make(map[string]string)
 				for _, e := range os.Environ() {
 					pair := strings.SplitN(e, "=", 2)
-					// if the key matches, add the value
-					if pair[0] == key {
+					// if the environment variable starts with the prefix, add it to the map
+					if strings.HasPrefix(pair[0], prefix) {
 						env[pair[0]] = pair[1]
 					}
 				}


### PR DESCRIPTION
Rename the custom `env` templating function to `osenv` and make it filter OS environment variables based of prefix.