### PR TITLE
[FIX] The extra [/] character on variable on Makefile duplicate the final path result 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TIMESTAMP = $(shell date -Iseconds -u)
 
 project = hockeypuck
 
-prefix = /usr
+prefix = usr
 statedir = /var/lib/$(project)
 
 commands = \


### PR DESCRIPTION
Hi, after trying the `sudo make install` command, despite it working without issues, it shows this output with a duplicate [ / ] on the math, I suggest the fix in this PR

![Captura de pantalla 2024-07-10 154045](https://github.com/hockeypuck/hockeypuck/assets/89636253/d2d6c238-1f5b-49d1-a123-83bd7c60eb81)

This is a fix for deleting the [ / ] character on the prefix variable