### PR TITLE
[FEATURE] Add return button to stats page

### DIFF
--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -10,6 +10,10 @@ table, th, td {
 }
 </style></head><body><h1>Hockeypuck OpenPGP Keyserver Statistics</h1>
 Taken at {{ .Now }}
+</br>
+</br>
+<div style="float:left;"><p class="muted credit small"><a href="/">Return to home</a></p></div>
+</br>
 <h2 id="settings">Settings</h2>
 <table>
 <tr><th>Hostname</th><td>{{ .Hostname }}</td></tr>


### PR DESCRIPTION
Hello, I was missing a "Return" button to return to the home page

![imagen](https://github.com/hockeypuck/hockeypuck/assets/89636253/cf2ef91d-70a0-4238-80e3-748a498fa0a2)

Here my suggestion

Close: #326