### PR TITLE
[FEATURE] handle Partner structs internally instead of ip addresses (closes #292 #258 #98)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,7 +11,7 @@ KOLANICH <kolan_n@mail.ru>
 Sebastian Wagner <sebastian.wagner@intevation.de>
 Stamatis Kavvadias (Σταμάτης Καββαδίας) <stamatis.kavvadias@gmail.com>
 Steven Wheeler <steventwheeler@gmail.com>
-Edward Leeh <e45lee@uwaterloo.ca>
+Edward Lee <e45lee@uwaterloo.ca>
 briannosaurus
 Simon Law <slaw@quantcast.com>
 Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
@@ -19,3 +19,6 @@ Petr Tesarik <petr@tesarici.cz>
 Thomas Cuthbert <tcuthbert90@gmail.com>
 Wiktor Kwapisiewicz <wiktor@metacode.biz>
 Andreas Puls
+Allen Zhong <allen@moe.cat>
+Robin H. Johnson <robbat2@orbis-terrarum.net>
+⚡️2FakTor⚡️ <twofaktor@protonmail.com>

--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -25,8 +25,8 @@ Taken at {{ .Now }}
 </table>
 
 <h3 id="gossip-peers">Gossip Peers</h3>
-<table><tr><th>Name</th><th>HTTP</th><th>Recon</th></tr>
-{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td></tr>
+<table><tr><th>Name</th><th>HTTP</th><th>Recon</th><th>Status</th></tr>
+{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td></tr>
 {{ end }}</table>
 
 <h2 id="statistics">Statistics</h2>

--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -25,8 +25,8 @@ Taken at {{ .Now }}
 </table>
 
 <h3 id="gossip-peers">Gossip Peers</h3>
-<table><tr><th>Name</th><th>HTTP</th><th>Recon</th><th>Status</th></tr>
-{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td></tr>
+<table><tr><th>Name</th><th>HTTP</th><th>Recon</th><th>Recon Status</th><th>Recovery Status</th></tr>
+{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td><td>{{ $peer.RecoveryStatus }}</td></tr>
 {{ end }}</table>
 
 <h2 id="statistics">Statistics</h2>

--- a/contrib/webroot/index.html
+++ b/contrib/webroot/index.html
@@ -29,6 +29,7 @@
         }
         .modal:target {
             display: block;
+            overflow-y: auto;
         }
     </style>
   </head>
@@ -153,7 +154,6 @@
             </div>
 
             <div class="modal-header">
-              <a href="#" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
               <h4 class="modal-title" id="AboutLabel">Personal Data</h4>
             </div>
             <div class="modal-body">
@@ -179,7 +179,6 @@
             </div>
 
             <div class="modal-header">
-              <a href="#" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
               <h4 class="modal-title" id="AboutLabel">The Software</h4>
             </div>
             <div class="modal-body">
@@ -191,7 +190,6 @@
             </div>
 
             <div class="modal-header">
-              <a href="#" type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
               <h4 class="modal-title" id="AboutLabel">The OpenPGP Standard</h4>
             </div>
             <div class="modal-body">

--- a/src/hockeypuck/conflux/recon/gossip.go
+++ b/src/hockeypuck/conflux/recon/gossip.go
@@ -73,11 +73,14 @@ func (p *Peer) Gossip() error {
 						p.logErr(GOSSIP, err).Debug()
 						recordReconBusyPeer(partner.Addr, CLIENT)
 					} else if err != nil {
+						partner.LastOutgoingError = err
 						p.logErr(GOSSIP, err).Errorf("recon with %v failed", partner)
 						recordReconFailure(partner.Addr, time.Since(start), CLIENT)
 					} else {
+						partner.LastOutgoingError = nil
 						recordReconSuccess(partner.Addr, time.Since(start), CLIENT)
 					}
+					partner.LastOutgoingRecon = start
 				}
 
 				p.readRelease()

--- a/src/hockeypuck/conflux/recon/gossip.go
+++ b/src/hockeypuck/conflux/recon/gossip.go
@@ -78,9 +78,9 @@ func (p *Peer) Gossip() error {
 						recordReconFailure(partner.Addr, time.Since(start), CLIENT)
 					} else {
 						partner.LastOutgoingError = nil
+						partner.LastOutgoingRecon = start
 						recordReconSuccess(partner.Addr, time.Since(start), CLIENT)
 					}
-					partner.LastOutgoingRecon = start
 				}
 
 				p.readRelease()

--- a/src/hockeypuck/conflux/recon/gossip.go
+++ b/src/hockeypuck/conflux/recon/gossip.go
@@ -96,7 +96,7 @@ var ErrPeerBusy error = fmt.Errorf("peer is busy handling another request")
 var ErrReconDone = fmt.Errorf("reconciliation done")
 
 func (p *Peer) choosePartner() (*Partner, error) {
-	partner, errorList := p.settings.RandomPartner()
+	partner, errorList := p.matcher.RandomPartner()
 	// Name resolution errors are not fatal unless partner==nil
 	for _, err := range errorList {
 		p.log(GOSSIP).Info(err.Error())

--- a/src/hockeypuck/conflux/recon/gossip.go
+++ b/src/hockeypuck/conflux/recon/gossip.go
@@ -108,7 +108,7 @@ func (p *Peer) choosePartner() (*Partner, error) {
 }
 
 func (p *Peer) InitiateRecon(partner *Partner) error {
-	p.log(GOSSIP).Infof("initiating recon with peer %v", partner.Addr)
+	p.log(GOSSIP).Infof("initiating recon to [%s]", partner.String())
 	conn, err := net.DialTimeout(partner.Addr.Network(), partner.Addr.String(), 30*time.Second)
 	if err != nil {
 		return errors.WithStack(err)

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -330,13 +330,13 @@ func (p *Peer) Serve() error {
 		return ln.Close()
 	})
 
-	var partner *Partner
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			return errors.WithStack(err)
 		}
 
+		var partner *Partner
 		if tcConn, ok := conn.(*net.TCPConn); ok {
 			tcConn.SetKeepAlive(true)
 			tcConn.SetKeepAlivePeriod(3 * time.Minute)

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -367,9 +367,9 @@ func (p *Peer) Serve() error {
 				recordReconFailure(conn.RemoteAddr(), time.Since(start), SERVER)
 			} else {
 				partner.LastIncomingError = nil
+				partner.LastIncomingRecon = start
 				recordReconSuccess(conn.RemoteAddr(), time.Since(start), SERVER)
 			}
-			partner.LastIncomingRecon = start
 			return nil
 		})
 		p.muDie.Unlock()

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -544,7 +544,7 @@ func (p *Peer) handleConfig(conn net.Conn, role string, failResp string) (_ *Con
 func (p *Peer) Accept(conn net.Conn, partner *Partner) (_err error) {
 	defer conn.Close()
 
-	p.logConn(SERVE, conn).Info("accepted connection")
+	p.log(SERVE).Infof("accepted recon from [%s]", partner.String())
 	defer func() {
 		if _err != nil {
 			p.logConnErr(SERVE, conn, _err).Error()

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -347,6 +347,10 @@ func (p *Peer) Serve() error {
 				conn.Close()
 				continue
 			}
+		} else {
+			log.Warningf("unsupported connection from %q", conn.RemoteAddr())
+			conn.Close()
+			continue
 		}
 
 		p.muDie.Lock()
@@ -355,6 +359,7 @@ func (p *Peer) Serve() error {
 			return nil
 		}
 		p.t.Go(func() error {
+			defer conn.Close()
 			err = p.Accept(conn, partner)
 			start := time.Now()
 			recordReconInitiate(conn.RemoteAddr(), SERVER)
@@ -548,8 +553,6 @@ func (p *Peer) handleConfig(conn net.Conn, role string, failResp string) (_ *Con
 }
 
 func (p *Peer) Accept(conn net.Conn, partner *Partner) (_err error) {
-	defer conn.Close()
-
 	p.log(SERVE).Infof("accepted recon from [%s]", partner.String())
 	defer func() {
 		if _err != nil {

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -63,8 +63,12 @@ func (r *Recover) HkpAddr() (string, error) {
 	}
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		log.Errorf("cannot parse HKP remote address from %q: %v", addr, err)
-		return "", errors.WithStack(err)
+		// Fall back to the connection IP if the Partner config doesn't work.
+		host, _, err = net.SplitHostPort(r.RemoteAddr.String())
+		if err != nil {
+			log.Errorf("cannot parse HKP remote address from %q: %v", addr, err)
+			return "", errors.WithStack(err)
+		}
 	}
 	if strings.Contains(host, ":") {
 		host = fmt.Sprintf("[%s]", host)

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -762,8 +762,6 @@ func (rwc *reconWithClient) flushQueue() error {
 	return nil
 }
 
-var zeroTime time.Time
-
 func (p *Peer) interactWithClient(conn net.Conn, remoteConfig *Config, partner *Partner, bitstring *cf.Bitstring) error {
 	p.logConn(SERVE, conn).Debug("interacting with client")
 	p.setReadDeadline(conn, defaultTimeout)

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -693,7 +693,7 @@ func (rwc *reconWithClient) sendRequest(p *Peer, req *requestEntry) error {
 	return nil
 }
 
-func (rwc *reconWithClient) handleReply(p *Peer, msg ReconMsg, req *requestEntry) error {
+func (rwc *reconWithClient) handleReply(msg ReconMsg, req *requestEntry) error {
 	rwc.Peer.logConnFields(SERVE, rwc.conn, log.Fields{"msg": msg}).Debug("handleReply")
 	switch m := msg.(type) {
 	case *SyncFail:
@@ -811,7 +811,7 @@ func (p *Peer) interactWithClient(conn net.Conn, remoteConfig *Config, partner *
 
 			if hasMsg {
 				recon.popBottom()
-				err = recon.handleReply(p, msg, bottom.requestEntry)
+				err = recon.handleReply(msg, bottom.requestEntry)
 				if err != nil {
 					return errors.WithStack(err)
 				}
@@ -830,7 +830,7 @@ func (p *Peer) interactWithClient(conn net.Conn, remoteConfig *Config, partner *
 						return errors.WithStack(err)
 					}
 					p.logConnFields(SERVE, conn, log.Fields{"msg": msg}).Debug("reply")
-					err = recon.handleReply(p, msg, bottom.requestEntry)
+					err = recon.handleReply(msg, bottom.requestEntry)
 					if err != nil {
 						return errors.WithStack(err)
 					}

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -359,10 +359,13 @@ func (p *Peer) Serve() error {
 				recordReconBusyPeer(conn.RemoteAddr(), SERVER)
 			} else if err != nil {
 				p.logErr(SERVE, err).Errorf("recon with %v failed", conn.RemoteAddr())
+				partner.LastIncomingError = err
 				recordReconFailure(conn.RemoteAddr(), time.Since(start), SERVER)
 			} else {
+				partner.LastIncomingError = nil
 				recordReconSuccess(conn.RemoteAddr(), time.Since(start), SERVER)
 			}
+			partner.LastIncomingRecon = start
 			return nil
 		})
 		p.muDie.Unlock()

--- a/src/hockeypuck/conflux/recon/peer.go
+++ b/src/hockeypuck/conflux/recon/peer.go
@@ -134,6 +134,10 @@ func NewMemPeer() *Peer {
 	return NewPeer(settings, tree)
 }
 
+func (p *Peer) CurrentPartners() []*Partner {
+	return p.matcher.CurrentPartners()
+}
+
 func (p *Peer) log(label string) *log.Entry {
 	return p.logFields(label, log.Fields{})
 }

--- a/src/hockeypuck/conflux/recon/peer_test.go
+++ b/src/hockeypuck/conflux/recon/peer_test.go
@@ -50,17 +50,17 @@ func (s *PeerSuite) TestResolveRecoverAddr(c *gc.C) {
 			},
 		}
 
-		hkpHostPort, err := r.HkpAddr()
+		recoverHostPort, err := r.RecoverAddr()
 		c.Assert(err, gc.IsNil)
 
-		hkpAddr, err := net.ResolveTCPAddr("tcp", hkpHostPort)
+		recoverAddr, err := net.ResolveTCPAddr("tcp", recoverHostPort)
 		c.Assert(err, gc.IsNil)
 
-		hkpHost, _, err := net.SplitHostPort(hkpHostPort)
+		recoverHost, _, err := net.SplitHostPort(recoverHostPort)
 		c.Assert(err, gc.IsNil)
 
-		c.Assert(hkpAddr.Port, gc.Equals, 8080)
-		c.Assert(reconAddr.IP, gc.DeepEquals, hkpAddr.IP)
-		c.Assert(testHost, gc.Equals, hkpHost)
+		c.Assert(recoverAddr.Port, gc.Equals, 8080)
+		c.Assert(reconAddr.IP, gc.DeepEquals, recoverAddr.IP)
+		c.Assert(testHost, gc.Equals, recoverHost)
 	}
 }

--- a/src/hockeypuck/conflux/recon/peer_test.go
+++ b/src/hockeypuck/conflux/recon/peer_test.go
@@ -42,6 +42,9 @@ func (s *PeerSuite) TestResolveRecoverAddr(c *gc.C) {
 		c.Assert(reconAddr.Port, gc.Equals, 11370)
 		r := &Recover{
 			RemoteAddr: reconAddr,
+			Partner: &Partner{
+				ReconAddr: testHostPort,
+			},
 			RemoteConfig: &Config{
 				HTTPPort: 8080,
 			},

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jmcvetta/randutil"
@@ -80,6 +81,11 @@ type Partner struct {
 	Addr net.Addr
 	// IPs is the set of source IPs allowed for incoming recon
 	IPs []net.IP
+	// Log of successes and failures
+	LastIncomingRecon time.Time
+	LastIncomingError error
+	LastOutgoingRecon time.Time
+	LastOutgoingError error
 }
 
 func (p *Partner) String() string {

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -142,11 +142,11 @@ func (m *ipMatcher) allowCIDR(cidr string) error {
 
 func (m *ipMatcher) Match(ip net.IP) *Partner {
 	if ip.IsLoopback() {
-		return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, ReconAddr: "localhost"}
+		return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}}
 	}
 	for _, matchNet := range m.nets {
 		if matchNet.Contains(ip) {
-			return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, ReconAddr: ip.String()}
+			return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}}
 		}
 	}
 	for _, matchPartner := range m.partners {

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -82,6 +82,10 @@ type Partner struct {
 	IPs []net.IP
 }
 
+func (p *Partner) String() string {
+	return fmt.Sprintf("recon=%s, http=%s, weight=%d, addr=%v, ips=%v", p.ReconAddr, p.HTTPAddr, p.Weight, p.Addr, p.IPs)
+}
+
 type matchAccessType uint8
 
 const (

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -84,6 +84,7 @@ type Partner struct {
 	// IPs is the set of source IPs allowed for incoming recon
 	IPs []net.IP
 	// Log of successes and failures
+	ReconStarted      time.Time
 	LastIncomingRecon time.Time
 	LastIncomingError error
 	LastOutgoingRecon time.Time
@@ -122,6 +123,7 @@ func newIPMatcher() *ipMatcher {
 func (m *ipMatcher) allow(name string, partner Partner) error {
 	partner.updateIPs()
 	partner.Name = name
+	partner.ReconStarted = time.Now()
 	m.partners = append(m.partners, &partner)
 	return nil
 }

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -105,23 +105,21 @@ func (m *ipMatcher) allow(partner Partner) error {
 	var reconHostname string
 	if partner.ReconNet == NetworkDefault || partner.ReconNet == NetworkTCP {
 		reconHostname, _, err := net.SplitHostPort(partner.ReconAddr)
-		if err != nil {
-			return err
-		}
-		ips, err := net.LookupIP(reconHostname)
 		if err == nil {
-			partner.IPs = ips
+			ips, err := net.LookupIP(reconHostname)
+			if err == nil {
+				partner.IPs = ips
+			}
 		}
 	}
 	if partner.HTTPNet == NetworkDefault || partner.HTTPNet == NetworkTCP {
 		httpHostname, _, err := net.SplitHostPort(partner.HTTPAddr)
-		if err != nil {
-			return err
-		}
-		if reconHostname != httpHostname {
-			ips, err := net.LookupIP(httpHostname)
-			if err == nil && reconHostname != httpHostname {
-				partner.IPs = append(partner.IPs, ips...)
+		if err == nil {
+			if reconHostname != httpHostname {
+				ips, err := net.LookupIP(httpHostname)
+				if err == nil && reconHostname != httpHostname {
+					partner.IPs = append(partner.IPs, ips...)
+				}
 			}
 		}
 	}
@@ -140,11 +138,11 @@ func (m *ipMatcher) allowCIDR(cidr string) error {
 
 func (m *ipMatcher) Match(ip net.IP) *Partner {
 	if ip.IsLoopback() {
-		return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, HTTPAddr: "localhost", ReconAddr: "localhost"}
+		return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, ReconAddr: "localhost"}
 	}
 	for _, matchNet := range m.nets {
 		if matchNet.Contains(ip) {
-			return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, HTTPAddr: ip.String(), ReconAddr: ip.String()}
+			return &Partner{IPs: []net.IP{ip}, Addr: &net.IPAddr{IP: ip, Zone: ""}, ReconAddr: ip.String()}
 		}
 	}
 	for _, matchPartner := range m.partners {
@@ -387,7 +385,7 @@ func (s *Settings) RandomPartner() (*Partner, []error) {
 				weight = 100
 			}
 			if weight > 0 {
-				choices = append(choices, randutil.Choice{Weight: weight, Item: partner})
+				choices = append(choices, randutil.Choice{Weight: weight, Item: &partner})
 			}
 		} else {
 			errorList = append(errorList, err)

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -89,6 +89,9 @@ type Partner struct {
 	LastIncomingError error
 	LastOutgoingRecon time.Time
 	LastOutgoingError error
+	// These are not used by conflux, but are provided so the caller can store recovery logs in a convenient place.
+	LastRecovery      time.Time
+	LastRecoveryError error
 }
 
 func (p *Partner) String() string {

--- a/src/hockeypuck/conflux/recon/settings_test.go
+++ b/src/hockeypuck/conflux/recon/settings_test.go
@@ -272,7 +272,7 @@ func (s *SettingsSuite) TestMatcher(c *gc.C) {
 	for _, tc := range testCases {
 		ip := net.ParseIP(tc.addr)
 		c.Assert(err, gc.IsNil)
-		result := matcher.Match(ip)
+		result := (matcher.Match(ip) != nil)
 		c.Check(result, gc.Equals, tc.expect, gc.Commentf("addr=%q", tc.addr))
 	}
 }
@@ -295,7 +295,7 @@ func (s *SettingsSuite) TestMatchAll(c *gc.C) {
 	for _, tc := range testCases {
 		ip := net.ParseIP(tc.addr)
 		c.Assert(err, gc.IsNil)
-		result := matcher.Match(ip)
+		result := matcher.Match(ip).IPs[0].Equal(ip)
 		c.Check(result, gc.Equals, tc.expect, gc.Commentf("addr=%q", tc.addr))
 	}
 }

--- a/src/hockeypuck/hkp/sks/recon.go
+++ b/src/hockeypuck/hkp/sks/recon.go
@@ -296,7 +296,11 @@ func (r *Peer) handleRecovery() error {
 			func() {
 				defer close(rcvr.Done)
 				if err := r.requestRecovered(rcvr); err != nil {
+					rcvr.Partner.LastRecoveryError = err
 					r.logAddr(RECON, rcvr.RemoteAddr).Errorf("recovery completed with errors: %v", err)
+				} else {
+					rcvr.Partner.LastRecoveryError = nil
+					rcvr.Partner.LastRecovery = time.Now()
 				}
 			}()
 		}

--- a/src/hockeypuck/hkp/sks/recon.go
+++ b/src/hockeypuck/hkp/sks/recon.go
@@ -149,6 +149,10 @@ func NewPeer(st storage.Storage, path string, s *recon.Settings, opts []openpgp.
 	return sksPeer, nil
 }
 
+func (p *Peer) CurrentPartners() []*recon.Partner {
+	return p.peer.CurrentPartners()
+}
+
 func (p *Peer) log(label string) *log.Entry {
 	return p.logFields(label, log.Fields{})
 }

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -302,10 +302,12 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 		reconStatus := "OK"
 		now := time.Now()
 		reconStaleLimit := time.Duration(s.settings.ReconStaleSecs) * time.Second
-		if v.LastIncomingError != nil || v.LastOutgoingError != nil {
-			reconStatus = "Error"
-		} else if v.LastIncomingRecon.Add(reconStaleLimit).Before(now) || v.LastOutgoingRecon.Add(reconStaleLimit).Before(now) {
-			reconStatus = "Stale"
+		if v.LastIncomingRecon.Add(reconStaleLimit).Before(now) && v.LastOutgoingRecon.Add(reconStaleLimit).Before(now) {
+			if v.ReconStarted.Add(reconStaleLimit).Before(now) {
+				reconStatus = "Stale"
+			} else {
+				reconStatus = "Starting"
+			}
 		}
 		result.Peers = append(result.Peers, statsPeer{
 			Name:              v.Name,

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -298,7 +298,7 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 		result.Daily = append(result.Daily, loadStat{LoadStat: v, Time: k})
 	}
 	sort.Sort(loadStats(result.Daily))
-	for k, v := range s.settings.Conflux.Recon.Settings.Partners {
+	for _, v := range s.sksPeer.CurrentPartners() {
 		reconStatus := "OK"
 		now := time.Now()
 		reconStaleLimit := time.Duration(s.settings.ReconStaleSecs) * time.Second
@@ -308,7 +308,7 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			reconStatus = "Stale"
 		}
 		result.Peers = append(result.Peers, statsPeer{
-			Name:              k,
+			Name:              v.Name,
 			HTTPAddr:          v.HTTPAddr,
 			ReconAddr:         v.ReconAddr,
 			LastIncomingRecon: v.LastIncomingRecon,

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -44,11 +44,6 @@ type reconConfig struct {
 	LevelDB levelDB `toml:"leveldb"`
 }
 
-const (
-	DefaultHKPBind           = ":11371"
-	DefaultLogRequestDetails = true
-)
-
 type HKPConfig struct {
 	Bind              string `toml:"bind"`
 	AdvBind           string `toml:"advertisedBind,omitempty"`
@@ -56,10 +51,6 @@ type HKPConfig struct {
 
 	Queries queryConfig `toml:"queries"`
 }
-
-const (
-	DefaultMaxResponseLen = 268435456
-)
 
 type queryConfig struct {
 	// Only respond with verified self-signed key material in queries
@@ -202,13 +193,18 @@ type Settings struct {
 	Version      string
 	BuiltAt      string
 
+	ReconStaleSecs int      `toml:"reconStaleSecs"`
 	MaxResponseLen int      `toml:"maxResponseLen"`
 	AdminKeys      []string `toml:"adminKeys"`
 }
 
 const (
-	DefaultLogLevel    = "INFO"
-	DefaultLevelDBPath = "recon.db"
+	DefaultLevelDBPath       = "recon.db"
+	DefaultHKPBind           = ":11371"
+	DefaultLogRequestDetails = true
+	DefaultLogLevel          = "INFO"
+	DefaultReconStaleSecs    = 86400
+	DefaultMaxResponseLen    = 268435456
 )
 
 var (
@@ -239,6 +235,7 @@ func DefaultSettings() Settings {
 		Software:       Software,
 		Version:        Version,
 		BuiltAt:        BuiltAt,
+		ReconStaleSecs: DefaultReconStaleSecs,
 		MaxResponseLen: DefaultMaxResponseLen,
 		AdminKeys:      []string{},
 	}


### PR DESCRIPTION
Significant refactoring of conflux to use Partner structs as the basic unit of information. IPMatcher and Recover now handle *Partner references instead of net.Addrs, meaning that:

* We can store remote IPs for matching (all of them! #258) in Partner structs
* ... and keep them updated as remote IP addresses change over time
* So we can return the matching Partner from Match() instead of a boolean
* Meaning the Host: header is now set correctly in outgoing hashqueries #292
* Logs are more informative
* Most recent sync state of each partner can be displayed in stats

As part of this refactoring, RandomPartner has been moved into IPMatcher, and IPMatcher is a static member of Peer, rather than a scope variable in (*Peer)Serve(). This is necessary because Settings contains a hash of Partner objects that are immutable (per the design of golang), so we mantain mutable copies in IPMatcher and the gossip randomiser obtains fresh *Partners from there instead of Settings. By storing IPMatcher as a member of Peer, we ensure that both incoming and outgoing gossip share the same []*Partner state. The stats page also gets its Partner list from IPMatcher so that it can display current status. 

Driveby fixes:

* Update CONTRIBUTORS
* Fix broken error handling in various places (including #98)
* Rename some variables for better clarity and consistency
* Various decrufting