### PR TITLE
Update data-sources.md to point to the right link

### DIFF
--- a/contrib/data-sources.md
+++ b/contrib/data-sources.md
@@ -7,5 +7,5 @@ These are provided on a best-effort basis and should be checked for consistency 
 
 Dumps are provided by two methods (should be identical content):
 
-* https://mirror.cyberbits.eu/sks/dump
-* rsync://rsync.cyberbits.eu/sks/dump
+* [https://mirror.cyberbits.eu/hockeypuck/dump](https://mirror.cyberbits.eu/hockeypuck/dump/)
+* rsync://rsync.cyberbits.eu/hockeypuck/dump


### PR DESCRIPTION
The previous link to the data sources seems to have been moved. I have updated the links to point to the right URLs.