### PR TITLE
Update standalone deployment of hockeypuck

### DIFF
--- a/contrib/docker-compose/standalone/sync-sks-dump.bash
+++ b/contrib/docker-compose/standalone/sync-sks-dump.bash
@@ -4,4 +4,4 @@ set -eu
 
 docker-compose -f docker-compose.yml -f docker-compose-tools.yml \
     run --rm --entrypoint /bin/sh import-keys \
-         -x -c 'rsync -avr --delete "rsync://rsync.cyberbits.eu/hockeypuck/dump/*.pgp" /import/dump'
+        -x -c 'rsync -avr --delete "rsync://rsync.cyberbits.eu/hockeypuck/dump/*.pgp" /import/dump'

--- a/contrib/docker-compose/standalone/sync-sks-dump.bash
+++ b/contrib/docker-compose/standalone/sync-sks-dump.bash
@@ -4,4 +4,4 @@ set -eu
 
 docker-compose -f docker-compose.yml -f docker-compose-tools.yml \
     run --rm --entrypoint /bin/sh import-keys \
-        -x -c 'rsync -avr rsync://rsync.cyberbits.eu/hockeypuck/dump/*.pgp /import'
+         -x -c 'rsync -avr --delete "rsync://rsync.cyberbits.eu/hockeypuck/dump/*.pgp" /import/dump'


### PR DESCRIPTION
# Description

- `sync-sks-dump.bash` was failing due to invalid link in the script, fixed that.
- The `docker-compose.yml` has the hockeypuck container with the volume pointing to `/hockeypuck/import/` whereas the `startup.sh` script invoked by it has the `keydump` variable pointing to `$hkp/import/dump`. Because of this, it fails to start up the container with the error `no keydump available` even though keydump is present.