### PR TITLE
Add some configurable variables to stats page

### DIFF
--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -26,7 +26,7 @@ Taken at {{ .Now }}
 
 <h3 id="gossip-peers">Gossip Peers</h3>
 <table><tr><th>Name</th><th>HTTP</th><th>Recon</th><th>Recon Status</th><th>Recovery Status</th></tr>
-{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}{{ $peer.StatsURI }}">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td><td>{{ $peer.RecoveryStatus }}</td></tr>
+{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}{{ $peer.StatsPath }}">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td><td>{{ $peer.RecoveryStatus }}</td></tr>
 {{ end }}</table>
 
 <h2 id="statistics">Statistics</h2>

--- a/contrib/templates/stats.html.tmpl
+++ b/contrib/templates/stats.html.tmpl
@@ -26,7 +26,7 @@ Taken at {{ .Now }}
 
 <h3 id="gossip-peers">Gossip Peers</h3>
 <table><tr><th>Name</th><th>HTTP</th><th>Recon</th><th>Recon Status</th><th>Recovery Status</th></tr>
-{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}/pks/lookup?op=stats">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td><td>{{ $peer.RecoveryStatus }}</td></tr>
+{{ range $peer := .Peers }}<tr><td>{{ $peer.Name }}</td><td><a href="http://{{ $peer.HTTPAddr }}{{ $peer.StatsURI }}">{{ $peer.HTTPAddr }}</a></td><td>{{ $peer.ReconAddr }}</td><td>{{ $peer.ReconStatus }}</td><td>{{ $peer.RecoveryStatus }}</td></tr>
 {{ end }}</table>
 
 <h2 id="statistics">Statistics</h2>

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -81,8 +81,8 @@ type Partner struct {
 	// to be accessed via a different domain/port than hockeypuck process.
 	// e.g., when there is a reverse proxy or load balancer
 	WebAddr string `toml:"webAddr"`
-	// StatsURI is the endpoint of stats page on this peer
-	StatsURI string `toml:"statsURI"`
+	// StatsPath is the endpoint of stats page on this peer
+	StatsPath string `toml:"statsPath"`
 	// Mask the HTTPAddr and ReconAddr shown in stats page
 	Mask bool `toml:"mask"`
 	// Name is a copy of the key used in the Settings map

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -81,6 +81,8 @@ type Partner struct {
 	// to be accessed via a different domain/port than hockeypuck process.
 	// e.g., when there is a reverse proxy or load balancer
 	WebAddr string `toml:"webAddr"`
+	// StatsURI is the endpoint of stats page on this peer
+	StatsURI string `toml:"statsURI"`
 	// Mask the HTTPAddr and ReconAddr shown in stats page
 	Mask bool `toml:"mask"`
 	// Name is a copy of the key used in the Settings map

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -77,6 +77,8 @@ type Partner struct {
 	ReconAddr string  `toml:"reconAddr"`
 	ReconNet  netType `toml:"reconNet" json:"-"`
 	Weight    int     `toml:"weight"`
+	// Mask the HTTPAddr and ReconAddr shown in stats page
+	Mask bool `toml:"mask" json:"masked"`
 	// Name is a copy of the key used in the Settings map
 	Name string
 	// Addr is the resolved address last used by outgoing recon

--- a/src/hockeypuck/conflux/recon/settings.go
+++ b/src/hockeypuck/conflux/recon/settings.go
@@ -77,8 +77,12 @@ type Partner struct {
 	ReconAddr string  `toml:"reconAddr"`
 	ReconNet  netType `toml:"reconNet" json:"-"`
 	Weight    int     `toml:"weight"`
+	// WebAddr overwrites HTTPAddr on stats page where the server is supposed
+	// to be accessed via a different domain/port than hockeypuck process.
+	// e.g., when there is a reverse proxy or load balancer
+	WebAddr string `toml:"webAddr"`
 	// Mask the HTTPAddr and ReconAddr shown in stats page
-	Mask bool `toml:"mask" json:"masked"`
+	Mask bool `toml:"mask"`
 	// Name is a copy of the key used in the Settings map
 	Name string
 	// Addr is the resolved address last used by outgoing recon

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -242,14 +242,14 @@ func (s loadStats) Len() int           { return len(s) }
 func (s loadStats) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s loadStats) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
 
-// default value of stats URI
-const defaultStatsURI = "/pks/lookup?op=stats"
+// default value of stats endpoint path
+const defaultStatsPath = "/pks/lookup?op=stats"
 
 type statsPeer struct {
 	Name              string
 	HTTPAddr          string `json:"httpAddr"`
 	ReconAddr         string `json:"reconAddr"`
-	StatsURI          string `json:"statsURI"`
+	StatsPath         string `json:"statsPath"`
 	Masked            bool   `json:"masked,omitempty"`
 	LastIncomingRecon time.Time
 	LastIncomingError string
@@ -339,7 +339,7 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			Name:              v.Name,
 			HTTPAddr:          v.HTTPAddr,
 			ReconAddr:         v.ReconAddr,
-			StatsURI:          defaultStatsURI,
+			StatsPath:         defaultStatsPath,
 			LastIncomingRecon: v.LastIncomingRecon,
 			LastIncomingError: fmt.Sprintf("%q", v.LastIncomingError),
 			LastOutgoingRecon: v.LastOutgoingRecon,
@@ -349,11 +349,11 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			LastRecoveryError: fmt.Sprintf("%q", v.LastRecoveryError),
 			RecoveryStatus:    recoveryStatus,
 		}
-		if v.StatsURI != "" {
-			if !strings.HasPrefix(v.StatsURI, "/") {
-				peerInfo.StatsURI = "/" + v.StatsURI
+		if v.StatsPath != "" {
+			if !strings.HasPrefix(v.StatsPath, "/") {
+				peerInfo.StatsPath = "/" + v.StatsPath
 			} else {
-				peerInfo.StatsURI = v.StatsURI
+				peerInfo.StatsPath = v.StatsPath
 			}
 		}
 		if v.WebAddr != "" {

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -239,10 +239,14 @@ func (s loadStats) Len() int           { return len(s) }
 func (s loadStats) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s loadStats) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
 
+// default value of stats URI
+var defaultStatsURI = "/pks/lookup?op=stats"
+
 type statsPeer struct {
 	Name              string
 	HTTPAddr          string `json:"httpAddr"`
 	ReconAddr         string `json:"reconAddr"`
+	StatsURI          string `json:"statsURI"`
 	Masked            bool   `json:"masked,omitempty"`
 	LastIncomingRecon time.Time
 	LastIncomingError string
@@ -332,6 +336,7 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			Name:              v.Name,
 			HTTPAddr:          v.HTTPAddr,
 			ReconAddr:         v.ReconAddr,
+			StatsURI:          defaultStatsURI,
 			LastIncomingRecon: v.LastIncomingRecon,
 			LastIncomingError: fmt.Sprintf("%q", v.LastIncomingError),
 			LastOutgoingRecon: v.LastOutgoingRecon,
@@ -340,6 +345,13 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			LastRecovery:      v.LastRecovery,
 			LastRecoveryError: fmt.Sprintf("%q", v.LastRecoveryError),
 			RecoveryStatus:    recoveryStatus,
+		}
+		if v.StatsURI != "" {
+			if !strings.HasPrefix(v.StatsURI, "/") {
+				peerInfo.StatsURI = "/" + v.StatsURI
+			} else {
+				peerInfo.StatsURI = v.StatsURI
+			}
 		}
 		if v.WebAddr != "" {
 			peerInfo.HTTPAddr = v.WebAddr

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -341,8 +341,11 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 			LastRecoveryError: fmt.Sprintf("%q", v.LastRecoveryError),
 			RecoveryStatus:    recoveryStatus,
 		}
+		if v.WebAddr != "" {
+			peerInfo.HTTPAddr = v.WebAddr
+		}
 		if v.Mask {
-			peerInfo.HTTPAddr = maskString(v.HTTPAddr)
+			peerInfo.HTTPAddr = maskString(peerInfo.HTTPAddr)
 			peerInfo.ReconAddr = maskString(v.ReconAddr)
 			peerInfo.Masked = true
 		}

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -227,6 +227,9 @@ type loadStat struct {
 
 // maskString replace input string with * to hide sensitive information
 func maskString(orig string) string {
+	if orig == "" {
+		return orig
+	}
 	if len(orig) < 4 {
 		return "******"
 	}
@@ -240,7 +243,7 @@ func (s loadStats) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s loadStats) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
 
 // default value of stats URI
-var defaultStatsURI = "/pks/lookup?op=stats"
+const defaultStatsURI = "/pks/lookup?op=stats"
 
 type statsPeer struct {
 	Name              string


### PR DESCRIPTION
Add some new configurable variables to the stats page.

In the `hockeypuck.conflux.recon.partner` list, for each partner peer, these variables are added:
 - `webAddr` (string): The domain / hostname to display on stats page. By default we use `example.com:11371`, for servers that have a reverse proxy or load balancer the default HTTP/HTTPS port could be used (so no port need to be specified) or a different domain may be used. This is also useful for some browsers and firewalls that only permit user to request HTTP services on common ports.
 - `statsPath` (string): The endpoint of stats page of the peer server, current default is `/pks/lookup?op=stats`. The `statsPath` key is also added to `mr` output. Close #370 
 - `mask` (boolean): If set `true`, the HTTP and Recon address displayed in stats page are replaced with a fixed-length 6-char-long masked version where only first and last character of the original string is displayed, e.g. `example.com:11371` will be replaced with `e****1` on the page. A `masked` flag is also added to the `mr` output for scripts to filter such peers. If both `webAddr` and `mask` are set, showing the masked version of `webAddr`. Close #372 