### PR TITLE
Add new docker-compose for proxied deployment

### DIFF
--- a/contrib/docker-compose/standalone/docker-compose-proxy.yml
+++ b/contrib/docker-compose/standalone/docker-compose-proxy.yml
@@ -1,0 +1,109 @@
+version: '3.7'
+services:
+  hockeypuck:
+    image: hockeypuck/hockeypuck:${RELEASE}
+    build:
+      context: ../../..
+    ports:
+    - "${HKP_RECON_HOST_PORT:-11370}:11370"
+    restart: always
+    environment:
+    - FQDN
+    - FINGERPRINT
+    - POSTGRES_USER
+    - POSTGRES_PASSWORD
+    - HKP_CONF_DIR=/hockeypuck/etc
+    depends_on:
+    - postgres
+    volumes:
+    - ./hockeypuck-entrypoint.sh:/usr/local/bin/hockeypuck-entrypoint.sh
+    - ./hockeypuck/etc:/hockeypuck/etc
+    - hkp_data:/hockeypuck/data
+    - pgp_import:/hockeypuck/import
+    entrypoint: /usr/local/bin/hockeypuck-entrypoint.sh
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  postgres:
+    image: postgres:${POSTGRES_VERSION:-11}
+    restart: always
+    environment:
+    - POSTGRES_USER
+    - POSTGRES_PASSWORD
+    - POSTGRES_DB=hkp
+    volumes:
+    - pg_data:/var/lib/postgresql/data
+
+  haproxy:
+    image: haproxy:2.6-alpine
+    ports:
+    - "${HAP_HTTP_HOST_PORT:-80}:80"
+    - "${HAP_HTTPS_HOST_PORT:-443}:443"
+    - "${HAP_HKP_HOST_PORT:-11371}:11371"
+    - "${HAP_PEER_HOST_PORT:-127.0.0.1:1395}:1395"
+    - "${HAP_ADMIN_HOST_PORT:-127.0.0.1:1396}:1396"
+    user: root
+    restart: always
+    init: true
+    hostname: haproxy
+    environment:
+    - FQDN
+    - ALIAS_FQDNS
+    - CLUSTER_FQDNS
+    - KEYSERVER_HOST_PORT=hockeypuck:11371
+    - HAP_DHPARAM_FILE=/etc/letsencrypt/ssl-dhparams.pem
+    - HAP_CONF_DIR=/usr/local/etc/haproxy
+    - HAP_CACHE_DIR=/var/cache/haproxy
+    - HAP_LOG_FORMAT
+    - HAP_BEHIND_CLOUDFLARE
+    - HAP_BEHIND_PROXY
+    - HAP_BEHIND_PROXY_EXCEPT_HKP
+    - HAP_DISABLE_PROMETHEUS=true
+    - HAP_DISABLE_CERTBOT=true
+    - HAP_DISABLE_SSL=true
+    depends_on:
+    - haproxy_cache
+    - haproxy_internal
+    volumes:
+    - ./haproxy-entrypoint.sh:/usr/local/bin/haproxy-entrypoint.sh
+    - ./haproxy/etc:/usr/local/etc/haproxy
+    - haproxy_cache:/var/cache/haproxy
+    entrypoint: "/usr/local/bin/haproxy-entrypoint.sh -f /usr/local/etc/haproxy/haproxy.d"
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  haproxy_internal:
+    image: haproxy:2.6-alpine
+    user: root
+    restart: always
+    hostname: haproxy-internal
+    ports:
+      - "${HAP_INTERNAL_ADMIN_HOST_PORT:-127.0.0.1:1397}:1396"
+    volumes:
+    - ./haproxy/etc/haproxy-internal.cfg:/usr/local/etc/haproxy/haproxy.cfg
+    entrypoint: "/bin/sh -c 'export HOSTNAME=$$(hostname); export HOST_IP=$$(hostname -i); haproxy -f /usr/local/etc/haproxy/haproxy.cfg'"
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  haproxy_cache:
+    image: instrumentisto/rsync-ssh
+    restart: always
+    volumes:
+    - haproxy_cache:/var/cache/haproxy
+    entrypoint: "/bin/sh -c 'trap exit TERM; touch /var/cache/haproxy/tor_exit_relays.list; while :; do sleep 1800; wget \"${TOR_EXIT_RELAYS_URL}\" -O /var/cache/haproxy/tor_exit_relays.list; done'"
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "1"
+
+volumes:
+  hkp_data: {}
+  pg_data: {}
+  pgp_import: {}
+  haproxy_cache: {}


### PR DESCRIPTION
**THIS IS A WORK IN PROGRESS DRAFT PR, DO NOT MERGE YET.**

@andrewgdotcom Following up on my email, here is the docker-compose file I'm using. It's a hybrid approach between the regular `docker-compose.yml` and `docker-compose-shim.yml`. I want to manage SSL/TLS certificates with my existing Caddy web server and reverse proxy requests to the Docker instances running Hockeypuck and HAProxy.

Please let me know if that would be useful and I'll add a proper README highlighting the required config in `.env` and how to tunnel TCP port 13370 for reconciliation.

Here's a diff for better understanding, basically I removed Prometheus and Certbot:

```diff
diff -u docker-compose.yml docker-compose-proxy.yml
--- docker-compose.yml	2024-05-28 13:23:43.152890952 +0000
+++ docker-compose-proxy.yml	2025-07-28 10:03:14.518770685 +0000
@@ -36,19 +36,6 @@
     volumes:
     - pg_data:/var/lib/postgresql/data
 
-  prometheus:
-    image: prom/prometheus:v2.43.0
-    restart: always
-    volumes:
-    - prom_data:/prometheus
-    - ./prometheus/etc:/etc/prometheus
-    command:
-    - "--web.external-url=/monitoring/prometheus/"
-    - "--config.file=/etc/prometheus/prometheus.yml"
-    - "--storage.tsdb.path=/prometheus"
-    - "--web.console.libraries=/usr/share/prometheus/console_libraries"
-    - "--web.console.templates=/usr/share/prometheus/consoles"
-
   haproxy:
     image: haproxy:2.6-alpine
     ports:
@@ -65,27 +52,24 @@
     - FQDN
     - ALIAS_FQDNS
     - CLUSTER_FQDNS
-    - PROMETHEUS_HOST_PORT=prometheus:9090
-    - CERTBOT_HOST_PORT=certbot:80
     - KEYSERVER_HOST_PORT=hockeypuck:11371
     - HAP_DHPARAM_FILE=/etc/letsencrypt/ssl-dhparams.pem
     - HAP_CONF_DIR=/usr/local/etc/haproxy
     - HAP_CACHE_DIR=/var/cache/haproxy
-    - HAP_CERT_DIR=/etc/letsencrypt/live
     - HAP_LOG_FORMAT
     - HAP_BEHIND_CLOUDFLARE
     - HAP_BEHIND_PROXY
     - HAP_BEHIND_PROXY_EXCEPT_HKP
+    - HAP_DISABLE_PROMETHEUS=true
+    - HAP_DISABLE_CERTBOT=true
+    - HAP_DISABLE_SSL=true
     depends_on:
-    - certbot
     - haproxy_cache
     - haproxy_internal
-    - prometheus
     volumes:
     - ./haproxy-entrypoint.sh:/usr/local/bin/haproxy-entrypoint.sh
     - ./haproxy/etc:/usr/local/etc/haproxy
     - haproxy_cache:/var/cache/haproxy
-    - ${CERTBOT_CONF:-certbot_conf}:/etc/letsencrypt
     entrypoint: "/usr/local/bin/haproxy-entrypoint.sh -f /usr/local/etc/haproxy/haproxy.d"
     logging:
       options:
@@ -118,17 +102,8 @@
         max-size: "10m"
         max-file: "1"
 
-  certbot:
-    image: certbot/certbot
-    restart: always
-    volumes:
-    - ${CERTBOT_CONF:-certbot_conf}:/etc/letsencrypt
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do for i in /etc/letsencrypt/live/*; do [ -d \"$$i\" ] && ln -sf privkey.pem $$i/fullchain.pem.key; certbot --standalone renew; done; sleep 12h & wait $${!}; done;'"
-
 volumes:
   hkp_data: {}
   pg_data: {}
-  prom_data: {}
   pgp_import: {}
   haproxy_cache: {}
-  certbot_conf: {}
```