### PR TITLE
Use exact matching by default in HKPv1 (closes #188)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,18 @@ prefix = /usr
 statedir = /var/lib/$(project)
 
 commands = \
-	hockeypuck \
-	hockeypuck-dump \
-	hockeypuck-load \
-	hockeypuck-pbuild \
-	hockeypuck-reload
+	$(project) \
+	$(project)-dump \
+	$(project)-load \
+	$(project)-pbuild \
+	$(project)-reload
 
 all: test build
 
 build:
 
 clean: clean-go
-	rm -rf debian/{.debhelper/,hockeypuck.debhelper.log,hockeypuck.postinst.debhelper,hockeypuck.postrm.debhelper,hockeypuck.prerm.debhelper,hockeypuck.substvars,hockeypuck/}
+	rm -rf debian/{.debhelper/,$(project).debhelper.log,$(project).postinst.debhelper,$(project).postrm.debhelper,$(project).prerm.debhelper,$(project).substvars,$(project)/}
 
 clean-go:
 	-chmod -R u+rwX pkg
@@ -38,9 +38,9 @@ deb-src:
 
 install:
 	mkdir -p -m 0755 $(DESTDIR)$(prefix)/bin
-	cp -a bin/hockeypuck* $(DESTDIR)$(prefix)/bin
-	mkdir -p -m 0755 $(DESTDIR)/etc/hockeypuck
-	cp -a contrib/config/hockeypuck.conf* $(DESTDIR)/etc/hockeypuck
+	cp -a bin/$(project)* $(DESTDIR)$(prefix)/bin
+	mkdir -p -m 0755 $(DESTDIR)/etc/$(project)
+	cp -a contrib/config/$(project).conf* $(DESTDIR)/etc/$(project)
 	mkdir -p -m 0755 $(DESTDIR)$(statedir)/templates
 	cp -a contrib/templates/*.tmpl $(DESTDIR)$(statedir)/templates
 	mkdir -p -m 0755 $(DESTDIR)$(statedir)/www
@@ -84,8 +84,8 @@ define make-go-cmd-target
 $(cmd_target):
 	cd $(SRCDIR) && \
 	go install -ldflags " \
-			-X hockeypuck/server.Version=$(VERSION) \
-			-X hockeypuck/server.BuiltAt=$(TIMESTAMP) \
+			-X $(project)/server.Version=$(VERSION) \
+			-X $(project)/server.BuiltAt=$(TIMESTAMP) \
 		" $(cmd_package)
 
 build: $(cmd_target)

--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -74,6 +75,9 @@ type Handler struct {
 
 	selfSignedOnly  bool
 	fingerprintOnly bool
+	enableInexact   bool
+
+	enumerableDomains []string
 
 	keyReaderOptions []openpgp.KeyReaderOption
 	keyWriterOptions []openpgp.KeyWriterOption
@@ -171,6 +175,20 @@ func SelfSignedOnly(selfSignedOnly bool) HandlerOption {
 func FingerprintOnly(fingerprintOnly bool) HandlerOption {
 	return func(h *Handler) error {
 		h.fingerprintOnly = fingerprintOnly
+		return nil
+	}
+}
+
+func EnableInexact(enableInexact bool) HandlerOption {
+	return func(h *Handler) error {
+		h.enableInexact = enableInexact
+		return nil
+	}
+}
+
+func EnumerableDomains(enumerableDomains []string) HandlerOption {
+	return func(h *Handler) error {
+		h.enumerableDomains = enumerableDomains
 		return nil
 	}
 }
@@ -532,7 +550,11 @@ func (h *Handler) fetchKeys(l *Lookup) ([]*openpgp.PrimaryKey, error) {
 			if h.fingerprintOnly {
 				return nil, errKeywordSearchNotAvailable
 			}
-			records, err = h.storage.FetchRecordsByKeyword(l.Search, storage.AutoPreen)
+			if (h.enableInexact && !l.Exact) || slices.Contains(h.enumerableDomains, l.Search) {
+				records, err = h.storage.FetchRecordsByKeyword(l.Search, storage.AutoPreen)
+			} else {
+				records, err = h.storage.FetchRecordsByIdentity([]string{l.Search}, storage.AutoPreen)
+			}
 		}
 	}
 	if err != nil {

--- a/src/hockeypuck/hkp/handler_test.go
+++ b/src/hockeypuck/hkp/handler_test.go
@@ -180,7 +180,7 @@ func (s *HandlerSuite) SetUpTest(c *gc.C) {
 	r := httprouter.New()
 	policy, err := openpgp.NewPolicy()
 	c.Assert(err, gc.IsNil)
-	handler, err := NewHandler(s.storage, policy, StatsFunc(s.StatsTest))
+	handler, err := NewHandler(s.storage, policy, StatsFunc(s.StatsTest), EnableInexact(true), EnumerableDomains([]string{"example.com"}))
 	c.Assert(err, gc.IsNil)
 	s.handler = handler
 	s.handler.Register(r)
@@ -289,7 +289,8 @@ func (s *HandlerSuite) TestGetKeyID(c *gc.C) {
 }
 
 func (s *HandlerSuite) TestGetKeyword(c *gc.C) {
-	res, err := http.Get(s.srv.URL + "/pks/lookup?op=get&search=alice")
+	// Test inexact matching of "alice" keyword
+	res, err := http.Get(s.srv.URL + "/pks/lookup?op=get&search=alice&exact=off")
 	c.Assert(err, gc.IsNil)
 	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
@@ -301,6 +302,35 @@ func (s *HandlerSuite) TestGetKeyword(c *gc.C) {
 	c.Assert(s.storage.MethodCount("FetchRecordsByFp"), gc.Equals, 0)
 	c.Assert(s.storage.MethodCount("FetchRecordsByVfp"), gc.Equals, 0)
 	c.Assert(s.storage.MethodCount("FetchRecordsByIdentity"), gc.Equals, 0)
+
+	// Test that enumerable domain search triggers inexact match with exact=on
+	// Note that MethodCount is cumulative
+	res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=example.com&exact=on")
+	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
+	c.Assert(err, gc.IsNil)
+	c.Assert(res.StatusCode, gc.Equals, http.StatusOK)
+
+	c.Assert(s.storage.MethodCount("FetchRecordsByMD5"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("ResolveToFp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByKeyword"), gc.Equals, 2)
+	c.Assert(s.storage.MethodCount("FetchRecordsByFp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByVfp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByIdentity"), gc.Equals, 0)
+
+	// Test that exact match is otherwise triggered with exact=on
+	res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=alice@example.com&exact=on")
+	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
+	c.Assert(err, gc.IsNil)
+	c.Assert(res.StatusCode, gc.Equals, http.StatusOK)
+
+	c.Assert(s.storage.MethodCount("FetchRecordsByMD5"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("ResolveToFp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByKeyword"), gc.Equals, 2)
+	c.Assert(s.storage.MethodCount("FetchRecordsByFp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByVfp"), gc.Equals, 0)
+	c.Assert(s.storage.MethodCount("FetchRecordsByIdentity"), gc.Equals, 1)
 }
 
 func (s *HandlerSuite) TestGetMD5(c *gc.C) {

--- a/src/hockeypuck/pghkp/storage_test.go
+++ b/src/hockeypuck/pghkp/storage_test.go
@@ -78,7 +78,7 @@ func (s *S) SetUpTest(c *gc.C) {
 
 	testAdminKeys := hkp.AdminKeys([]string{"0x5B74AE43F908323506BD2DFD31EDE6D1DF9E2BAF"})
 	r := httprouter.New()
-	handler, err := hkp.NewHandler(s.storage, policy, testAdminKeys)
+	handler, err := hkp.NewHandler(s.storage, policy, testAdminKeys, hkp.EnableInexact(true), hkp.EnumerableDomains([]string{"example.com"}))
 	c.Assert(err, gc.IsNil)
 	handler.Register(r)
 	s.srv = httptest.NewServer(r)
@@ -301,7 +301,7 @@ func (s *S) TestResolve(c *gc.C) {
 		// full textual IDs that include characters special to tsquery match
 		"Casey+Marshall+<casey.marshall@gmail.com>"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		defer res.Body.Close()
 		armor, err := io.ReadAll(res.Body)
@@ -335,7 +335,7 @@ func (s *S) TestResolve(c *gc.C) {
 		"0xdeadbeef", "0xce353cf4", "0xd1db", "44a2d1db", "0xadaf79362da44a2d1db",
 		"alice@example.com", "bob@example.com", "com"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		res.Body.Close()
 		c.Assert(res.StatusCode, gc.Equals, http.StatusNotFound, comment)
@@ -374,7 +374,7 @@ func (s *S) TestResolveWithHyphen(c *gc.C) {
 		// full textual IDs that include characters special to tsquery match
 		"steven-12345+(Test+Encryption)+<steven-test@example.com>"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		defer res.Body.Close()
 		armor, err := io.ReadAll(res.Body)
@@ -393,7 +393,7 @@ func (s *S) TestResolveWithHyphen(c *gc.C) {
 		"0xdeadbeef", "0xce353cf4", "0xc2c3", "2632c2c3", "0x8393287f5a32632c2c3",
 		"alice@example.com", "bob@example.com", "com"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		res.Body.Close()
 		c.Assert(res.StatusCode, gc.Equals, http.StatusNotFound, comment)
@@ -437,7 +437,7 @@ func (s *S) TestResolveBareEmail(c *gc.C) {
 		// full textual IDs that include characters special to tsquery match
 		"<support@posteo.de>"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		defer res.Body.Close()
 		armor, err := io.ReadAll(res.Body)
@@ -456,7 +456,7 @@ func (s *S) TestResolveBareEmail(c *gc.C) {
 		"0xdeadbeef", "0xce353cf4", "0x7c77", "573f7c77", "0xd9fa4eb82d2573f7c77",
 		"alice@example.com", "bob@example.com", "posteo"} {
 		comment := gc.Commentf("search=%s", search)
-		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err = http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		c.Assert(err, gc.IsNil, comment)
 		res.Body.Close()
 		c.Assert(res.StatusCode, gc.Equals, http.StatusNotFound, comment)
@@ -536,7 +536,7 @@ func (s *S) TestEd25519(c *gc.C) {
 		// contiguous words and email addresses match
 		"casey", "marshall", "casey+marshall", "cAseY+MArSHaLL",
 		"cmars@cmarstech.com", "casey.marshall@canonical.com"} {
-		res, err := http.Get(s.srv.URL + "/pks/lookup?op=get&search=" + search)
+		res, err := http.Get(s.srv.URL + "/pks/lookup?op=get&exact=off&search=" + search)
 		comment := gc.Commentf("search=%s", search)
 		c.Assert(err, gc.IsNil, comment)
 		defer res.Body.Close()

--- a/src/hockeypuck/server/cmd/hockeypuck/main.go
+++ b/src/hockeypuck/server/cmd/hockeypuck/main.go
@@ -25,7 +25,10 @@ func main() {
 		cmd.Die(err)
 	}
 
-	srv.Start()
+	err = srv.Start()
+	if err != nil {
+		cmd.Die(err)
+	}
 
 	cmd.Sigmap[syscall.SIGINT] = srv.Stop
 	cmd.Sigmap[syscall.SIGTERM] = srv.Stop

--- a/src/hockeypuck/server/server.go
+++ b/src/hockeypuck/server/server.go
@@ -173,6 +173,8 @@ func NewServer(settings *Settings) (*Server, error) {
 		hkp.StatsFunc(s.stats),
 		hkp.SelfSignedOnly(settings.HKP.Queries.SelfSignedOnly),
 		hkp.FingerprintOnly(settings.HKP.Queries.FingerprintOnly),
+		hkp.EnableInexact(settings.HKP.Queries.EnableInexact),
+		hkp.EnumerableDomains(settings.OpenPGP.EnumerableDomains),
 		hkp.KeyReaderOptions(keyReaderOptions),
 		hkp.KeyWriterOptions(keyWriterOptions),
 		hkp.AdminKeys(settings.AdminKeys),
@@ -242,6 +244,7 @@ type stats struct {
 type statsQueryConfig struct {
 	SelfSignedOnly  bool `json:"selfSignedOnly"`
 	FingerprintOnly bool `json:"keywordSearchDisabled"`
+	EnableInexact   bool `json:"enableInexactMatching"`
 }
 
 type loadStat struct {
@@ -302,6 +305,7 @@ func (s *Server) stats(req *http.Request) (interface{}, error) {
 		QueryConfig: statsQueryConfig{
 			SelfSignedOnly:  s.settings.HKP.Queries.SelfSignedOnly,
 			FingerprintOnly: s.settings.HKP.Queries.FingerprintOnly,
+			EnableInexact:   s.settings.HKP.Queries.EnableInexact,
 		},
 		ReconAddr: s.settings.Conflux.Recon.Settings.ReconAddr,
 		Software:  s.settings.Software,

--- a/src/hockeypuck/server/settings.go
+++ b/src/hockeypuck/server/settings.go
@@ -64,10 +64,9 @@ type queryConfig struct {
 }
 
 type HKPSConfig struct {
-	Bind              string `toml:"bind"`
-	LogRequestDetails bool   `toml:"logRequestDetails"`
-	Cert              string `toml:"cert"`
-	Key               string `toml:"key"`
+	Bind string `toml:"bind"`
+	Cert string `toml:"cert"`
+	Key  string `toml:"key"`
 }
 
 const (


### PR DESCRIPTION
- **Use exact matching by default in HKPv1 (closes #188)**
- **fix test suite**
- **parameterise Makefile**
- **handle startup errors (none so far)**
- **remove unused HKPS.LogRequestDetails setting**
