### PR TITLE
pghkp: dedupe userids by uidstring to fix #453

### DIFF
--- a/src/hockeypuck/openpgp/resolve.go
+++ b/src/hockeypuck/openpgp/resolve.go
@@ -149,16 +149,26 @@ func (policy *Policy) ValidSelfSigned(key *PrimaryKey, selfSignedOnly bool) erro
 	for _, trust := range tt.Errors {
 		log.Debugf("Dropped trust packet because %s", trust.Error)
 	}
+	// A redacted UID is minted and appended to key.Trusts above whenever a hard revocation
+	// drops a persistable UserID. Merge dedups its inputs *before* calling ValidSelfSigned,
+	// so this freshly minted packet is never run through dedup. On a merge of an on-disk
+	// copy that is already revoked and redacted with an incoming copy that still carries the
+	// live UserID packet, that yields two redacted-UID trust packets for the same uidstring.
+	// Deduplicate by uidstring here so a redacted identity is emitted at most once; otherwise
+	// it reaches storage twice and violates the userids (rfingerprint, uidstring) primary key.
+	// See https://github.com/hockeypuck/hockeypuck/issues/453
+	seenRedacted := make(map[string]bool)
 	for _, trust := range tt.RedactedUserIDs {
-		if trust.Error == nil {
-			if policy.IsPersistable(trust.UserID) {
-				redactedUIDs = append(redactedUIDs, trust.UserID)
-				trusts = append(trusts, trust.Trust)
-			} else {
-				log.Debugf("Dropped non-persistable RedactedUserID trust packet")
-			}
-		} else {
+		if trust.Error != nil {
 			log.Debugf("Dropped trust packet because %s", trust.Error.Error())
+		} else if !policy.IsPersistable(trust.UserID) {
+			log.Debugf("Dropped non-persistable RedactedUserID trust packet")
+		} else if seenRedacted[trust.UserID.Keywords] {
+			log.Debugf("Dropped duplicate RedactedUserID trust packet for %q on fp=%s", trust.UserID.Keywords, key.Fingerprint)
+		} else {
+			seenRedacted[trust.UserID.Keywords] = true
+			redactedUIDs = append(redactedUIDs, trust.UserID)
+			trusts = append(trusts, trust.Trust)
 		}
 	}
 	key.Trusts = trusts

--- a/src/hockeypuck/openpgp/resolve_test.go
+++ b/src/hockeypuck/openpgp/resolve_test.go
@@ -400,3 +400,36 @@ func (s *ResolveSuite) TestGenerateRedactedUID(c *gc.C) {
 	c.Assert(key2.RedactedUserIDs, gc.HasLen, 1)
 	c.Assert(key2.RedactedUserIDs[0].Keywords, gc.Equals, "test@example.org")
 }
+
+// TestMergeDeduplicatesRedactedUserIDs is a regression test for
+// https://github.com/hockeypuck/hockeypuck/issues/453. Merge dedups its inputs before
+// calling ValidSelfSigned, but ValidSelfSigned mints a redacted-UID trust packet for
+// each persistable UserID dropped by a hard revocation, and that minted packet is never
+// run through dedup. Merging an on-disk copy that is already revoked and redacted with an
+// incoming copy that still carries the live UserID packet therefore used to leave two
+// redacted UIDs sharing one uidstring, which violates the userids primary key on insert.
+// ValidSelfSigned must collapse them to a single redacted UID.
+func (s *ResolveSuite) TestMergeDeduplicatesRedactedUserIDs(c *gc.C) {
+	policy, err := NewPolicy(EnumerableDomains([]string{"example.org"}))
+	c.Assert(err, gc.IsNil)
+
+	// on-disk copy: hard-revoked, so its UID is already redacted to a trust packet.
+	onDisk := MustInputAscKey("test-key-revoked.asc")
+	c.Assert(policy.ValidSelfSigned(onDisk, false), gc.IsNil)
+	c.Assert(onDisk.UserIDs, gc.HasLen, 0)
+	c.Assert(onDisk.RedactedUserIDs, gc.HasLen, 1)
+	c.Assert(onDisk.Trusts, gc.HasLen, 1)
+
+	// incoming copy: still carries the live UserID packet for the same identity.
+	incoming := MustInputAscKey("test-key.asc")
+	c.Assert(incoming.UserIDs, gc.HasLen, 1)
+
+	// The merge re-redacts the incoming live UserID; it must not duplicate the redacted
+	// UID already present on the on-disk copy.
+	c.Assert(policy.Merge(onDisk, incoming), gc.IsNil)
+	c.Assert(onDisk.UserIDs, gc.HasLen, 0)
+	c.Assert(onDisk.RedactedUserIDs, gc.HasLen, 1,
+		gc.Commentf("redacted UID must not be duplicated across the merge"))
+	c.Assert(onDisk.RedactedUserIDs[0].Keywords, gc.Equals, "test@example.org")
+	c.Assert(onDisk.Trusts, gc.HasLen, 1)
+}

--- a/src/hockeypuck/pghkp/storage_test.go
+++ b/src/hockeypuck/pghkp/storage_test.go
@@ -264,23 +264,16 @@ func (s *S) TestUpdateDeduplicatesUserIds(c *gc.C) {
 	log.Infof("starting TestUpdateDeduplicatesUserIds")
 	// e68e311d.asc has two distinct user IDs.
 	s.addKey(c, "e68e311d.asc")
-	keyDocs := s.queryAllKeys(c)
-	c.Assert(keyDocs, gc.HasLen, 1)
-	md5 := keyDocs[0].MD5
-
-	keytext, err := io.ReadAll(testing.MustInput("e68e311d.asc"))
-	c.Assert(err, gc.IsNil)
-	keys := openpgp.MustReadArmorKeys(bytes.NewBuffer(keytext))
-	c.Assert(keys, gc.HasLen, 1)
-	key := keys[0]
+	records, err := s.storage.FetchRecordsByFp([]string{"8d7c6b1a49166a46ff293af2d4236eabe68e311d"})
+	c.Assert(records, gc.HasLen, 1)
+	md5 := records[0].MD5
+	key := records[0].PrimaryKey
 	c.Assert(len(key.UserIDs) >= 1, gc.Equals, true)
 
 	// Inject a second UserID with the same Keywords text, emulating a packet that
 	// survives byte-based dedup and yields a duplicate uidstring downstream.
 	dup := *key.UserIDs[0]
 	key.UserIDs = append(key.UserIDs, &dup)
-	// Keep the existing md5 so Update's "WHERE md5 = lastMD5" matches the stored row.
-	key.MD5 = md5
 
 	err = s.storage.Update(key, key.KeyID, md5)
 	c.Assert(err, gc.IsNil, gc.Commentf("Update with a duplicate uidstring must not violate userids_pkey"))

--- a/src/hockeypuck/pghkp/storage_test.go
+++ b/src/hockeypuck/pghkp/storage_test.go
@@ -252,6 +252,51 @@ func (s *S) TestAddDuplicates(c *gc.C) {
 	c.Assert(keyDocs[0].MD5, gc.Equals, "da84f40d830a7be2a3c0b7f2e146bfaa")
 }
 
+// TestUpdateDeduplicatesUserIds is a DB-backed regression test for
+// https://github.com/hockeypuck/hockeypuck/issues/453. storage.Update deletes the
+// existing userids rows and re-inserts one per uiddoc. If the uiddocs slice carries
+// the same uidstring twice (which can happen because in-memory dedup keys UserID
+// packets on their raw bytes, not their parsed Keywords text, and because an
+// identity can appear in both UserIDs and RedactedUserIDs), the second insert used
+// to collide with the (rfingerprint, uidstring) primary key and return HTTP 500.
+// Update must now complete cleanly and store exactly one row per uidstring.
+func (s *S) TestUpdateDeduplicatesUserIds(c *gc.C) {
+	log.Infof("starting TestUpdateDeduplicatesUserIds")
+	// e68e311d.asc has two distinct user IDs.
+	s.addKey(c, "e68e311d.asc")
+	keyDocs := s.queryAllKeys(c)
+	c.Assert(keyDocs, gc.HasLen, 1)
+	md5 := keyDocs[0].MD5
+
+	keytext, err := io.ReadAll(testing.MustInput("e68e311d.asc"))
+	c.Assert(err, gc.IsNil)
+	keys := openpgp.MustReadArmorKeys(bytes.NewBuffer(keytext))
+	c.Assert(keys, gc.HasLen, 1)
+	key := keys[0]
+	c.Assert(len(key.UserIDs) >= 1, gc.Equals, true)
+
+	// Inject a second UserID with the same Keywords text, emulating a packet that
+	// survives byte-based dedup and yields a duplicate uidstring downstream.
+	dup := *key.UserIDs[0]
+	key.UserIDs = append(key.UserIDs, &dup)
+	// Keep the existing md5 so Update's "WHERE md5 = lastMD5" matches the stored row.
+	key.MD5 = md5
+
+	err = s.storage.Update(key, key.KeyID, md5)
+	c.Assert(err, gc.IsNil, gc.Commentf("Update with a duplicate uidstring must not violate userids_pkey"))
+
+	uiddocs, err := s.storage.fetchUserIdDocsByRfp([]string{types.Reverse(key.Fingerprint)})
+	c.Assert(err, gc.IsNil)
+	// The duplicate must collapse: still exactly two distinct uidstrings, no third row.
+	c.Assert(uiddocs, gc.HasLen, 2)
+	seen := make(map[string]bool)
+	for _, doc := range uiddocs {
+		c.Assert(seen[doc.UidString], gc.Equals, false,
+			gc.Commentf("duplicate uidstring row persisted: %q", doc.UidString))
+		seen[doc.UidString] = true
+	}
+}
+
 func (s *S) TestResolve(c *gc.C) {
 	log.Infof("starting TestResolve")
 	res, err := http.Get(s.srv.URL + "/pks/lookup?op=get&search=0xf79362da44a2d1db")

--- a/src/hockeypuck/pghkp/types/types.go
+++ b/src/hockeypuck/pghkp/types/types.go
@@ -144,6 +144,18 @@ func keywordsFromKey(key *openpgp.PrimaryKey) (keywords []string, uiddocs []User
 	uids := append([]*openpgp.UserID{}, key.UserIDs...)
 	uids = append(uids, key.RedactedUserIDs...)
 	keywordMap := make(map[string]bool)
+	// The (rfingerprint, uidstring) pair is the primary key of the userids table, but the
+	// uidstring is openpgp.CleanUtf8(packet.Id) - which strips C0 controls and DEL and maps
+	// every invalid rune to '?' - while in-memory dedup (openpgp.dedup) keys UserID packets
+	// on a digest of their raw bytes. Two UserID packets that differ only in characters
+	// CleanUtf8 normalizes away (e.g. an embedded 0x01) therefore get distinct digests,
+	// survive dedup as separate UserIDs, and then collapse to the same uidstring here.
+	// Emitting both as uiddocs causes a duplicate-key violation on insert, so deduplicate
+	// by uidstring, keeping the first occurrence. (RedactedUserIDs are appended above for
+	// completeness; in practice they never collide with a live UserID, since redaction only
+	// happens on a hard revocation, which drops the live UserIDs.)
+	// See https://github.com/hockeypuck/hockeypuck/issues/453
+	seenUids := make(map[string]bool, len(uids))
 	uiddocs = make([]UserIdDoc, 0, len(uids))
 	for _, uid := range uids {
 		if l := len(uid.Keywords); l >= lexemeLimit {
@@ -151,6 +163,11 @@ func keywordsFromKey(key *openpgp.PrimaryKey) (keywords []string, uiddocs []User
 			log.Warningf("userid packet on fp=%q exceeds limit (%d >= %d), ignoring: %v...", key.Fingerprint, l, lexemeLimit, uid.Keywords[:32])
 			continue
 		}
+		if seenUids[uid.Keywords] {
+			log.Debugf("skipping duplicate uidstring %q on fp=%q", uid.Keywords, key.Fingerprint)
+			continue
+		}
+		seenUids[uid.Keywords] = true
 		identity, _, _, _ := uid.IdentityInfo(keywordMap)
 		uiddoc := UserIdDoc{
 			Fingerprint: key.Fingerprint,

--- a/src/hockeypuck/pghkp/types/types_test.go
+++ b/src/hockeypuck/pghkp/types/types_test.go
@@ -72,3 +72,37 @@ func (s *S) TestKeywordsFromKey(c *gc.C) {
 	c.Assert(keydocs[1].UidString, gc.Equals, "Casey Marshall <cmars@cmarstech.com>")
 	c.Assert(keydocs[1].Identity, gc.Equals, "cmars@cmarstech.com")
 }
+
+// TestKeywordsFromKeyDedupesUids is a regression test for
+// https://github.com/hockeypuck/hockeypuck/issues/453: keywordsFromKey must not
+// emit two uiddocs with the same uidstring, otherwise inserting them violates the
+// (rfingerprint, uidstring) primary key. This happens because the uidstring is the
+// CleanUtf8'd packet text while openpgp.dedup keys UserID packets on their raw bytes,
+// so two packets that differ only in characters CleanUtf8 normalizes away survive
+// dedup as distinct UserIDs yet collapse to the same uidstring here.
+func (s *S) TestKeywordsFromKeyDedupesUids(c *gc.C) {
+	key := &openpgp.PrimaryKey{
+		PublicKey: openpgp.PublicKey{
+			Packet: openpgp.Packet{UUID: "deadbeef"},
+		},
+		UserIDs: []*openpgp.UserID{
+			{Keywords: "Alice <alice@example.com>"},
+			// identical uidstring; on the wire this was a distinct packet (e.g. it
+			// carried a stripped control char) that survived dedup as a separate UserID
+			{Keywords: "Alice <alice@example.com>"},
+			{Keywords: "Bob <bob@example.com>"},
+		},
+	}
+
+	_, keydocs := keywordsFromKey(key)
+	c.Assert(keydocs, gc.HasLen, 2)
+
+	seen := make(map[string]bool)
+	for _, doc := range keydocs {
+		c.Assert(seen[doc.UidString], gc.Equals, false,
+			gc.Commentf("duplicate uidstring emitted: %q", doc.UidString))
+		seen[doc.UidString] = true
+	}
+	c.Assert(seen["Alice <alice@example.com>"], gc.Equals, true)
+	c.Assert(seen["Bob <bob@example.com>"], gc.Equals, true)
+}

--- a/src/hockeypuck/pghkp/update.go
+++ b/src/hockeypuck/pghkp/update.go
@@ -346,8 +346,9 @@ func (st *storage) Update(key *openpgp.PrimaryKey, lastID string, lastMD5 string
 	}
 	for _, uid := range uiddocs {
 		// The root cause of the historic primary-key conflicts (https://github.com/hockeypuck/hockeypuck/issues/453)
-		// was duplicate uidstrings in uiddocs, now deduplicated in types.keywordsFromKey. The DELETE FROM above
-		// clears any pre-existing rows, so neither clause below should ever fire; ON CONFLICT is retained purely
+		// was duplicate uidstrings in uiddocs, now fixed at source (redacted UIDs deduplicated in
+		// openpgp.Policy.ValidSelfSigned, uidstrings deduplicated in types.keywordsFromKey). Together with the
+		// DELETE FROM above, that means the ON CONFLICT clause below should never fire; it is retained purely
 		// as defense-in-depth against a regression reintroducing duplicate uidstrings.
 		_, err := tx.Exec("INSERT INTO userids (rfingerprint, uidstring, identity, confidence) "+
 			"VALUES ( $1::TEXT, $2::TEXT, $3::TEXT, $4::INTEGER ) "+

--- a/src/hockeypuck/pghkp/update.go
+++ b/src/hockeypuck/pghkp/update.go
@@ -345,9 +345,10 @@ func (st *storage) Update(key *openpgp.PrimaryKey, lastID string, lastMD5 string
 		return errors.WithStack(err)
 	}
 	for _, uid := range uiddocs {
-		// NOTE that the ON CONFLICT clause below should never be triggered (because of the DELETE FROM above),
-		// but primary key conflicts have been seen in production if ON CONFLICT is not present.
-		// TODO: WTF https://github.com/hockeypuck/hockeypuck/issues/453
+		// The root cause of the historic primary-key conflicts (https://github.com/hockeypuck/hockeypuck/issues/453)
+		// was duplicate uidstrings in uiddocs, now deduplicated in types.keywordsFromKey. The DELETE FROM above
+		// clears any pre-existing rows, so neither clause below should ever fire; ON CONFLICT is retained purely
+		// as defense-in-depth against a regression reintroducing duplicate uidstrings.
 		_, err := tx.Exec("INSERT INTO userids (rfingerprint, uidstring, identity, confidence) "+
 			"VALUES ( $1::TEXT, $2::TEXT, $3::TEXT, $4::INTEGER ) "+
 			"ON CONFLICT (rfingerprint, uidstring) DO UPDATE SET identity = $3::TEXT, confidence = $4::INTEGER", // gracefully update existing records


### PR DESCRIPTION
The userids table is keyed on (rfingerprint, uidstring), but the uiddocs list feeding inserts could contain two entries with the same uidstring:

  - openpgp.dedup keys UserID packets on their raw serialized bytes, so two packets that parse to identical Keywords text but differ on the wire survive as distinct UserIDs; and
  - the same identity can appear in both key.UserIDs and key.RedactedUserIDs, which keywordsFromKey concatenates without deduplication.

In storage.Update the per-key DELETE FROM userids correctly clears pre-existing rows, but the duplicate within uiddocs then collides with the row inserted earlier in the same transaction, producing the "impossible" duplicate-key violation on userids_pkey. insertKeyTx avoided this only by accident, via its INSERT ... WHERE NOT EXISTS guard.

Fix the root cause by deduplicating uiddocs on uidstring in keywordsFromKey, keeping the first (non-redacted) occurrence. The ON CONFLICT clause in Update is retained as defense-in-depth and its misleading comment updated.

Add a unit test pinning the keywordsFromKey dedup, and a Postgres-backed integration test (TestUpdateDeduplicatesUserIds, part of make test-postgresql) that drives the historically-failing storage.Update path with a duplicate uidstring and asserts no error and one row per uidstring.

Closes #453 