### PR TITLE
hkp/pghkp: DRY the storage write path; make Upsert/Replace/Delete own…

### DIFF
--- a/src/hockeypuck/hkp/handler.go
+++ b/src/hockeypuck/hkp/handler.go
@@ -313,7 +313,7 @@ func (h *Handler) HashQuery(w http.ResponseWriter, r *http.Request, _ httprouter
 			err = h.policy.ValidSelfSigned(key, false)
 			if err == openpgp.ErrKeyEvaporated {
 				// This is most likely caused by our storage containing invalid cruft. Delete it.
-				_, err := storage.DeleteKey(h.storage, key.Fingerprint)
+				_, err := h.storage.Delete(key.Fingerprint)
 				if err != nil {
 					log.Warnf("could not delete evaporated key %s: %s", key.Fingerprint, err.Error())
 					break
@@ -325,7 +325,7 @@ func (h *Handler) HashQuery(w http.ResponseWriter, r *http.Request, _ httprouter
 				// Stop processing after the first good key; don't hog the cpu.
 				break
 			}
-			storage.UpsertKey(h.storage, key, h.policy)
+			h.storage.Upsert(key)
 		}
 	}
 
@@ -650,7 +650,7 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request, _ httprouter.Param
 			continue
 		}
 
-		change, err := storage.UpsertKey(h.storage, key, h.policy)
+		change, err := h.storage.Upsert(key)
 		if err != nil {
 			httpError(w, http.StatusInternalServerError, errors.WithStack(err))
 			return
@@ -719,7 +719,7 @@ func (h *Handler) Replace(w http.ResponseWriter, r *http.Request, _ httprouter.P
 			return
 		}
 
-		change, err := storage.ReplaceKey(h.storage, key)
+		change, err := h.storage.Replace(key)
 		if err != nil {
 			if errors.Is(err, storage.ErrKeyNotFound) {
 				httpError(w, http.StatusNotFound, errors.WithStack(err))
@@ -791,7 +791,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		return
 	}
 	for _, key := range keys {
-		change, err := storage.DeleteKey(h.storage, key.Fingerprint)
+		change, err := h.storage.Delete(key.Fingerprint)
 		if err != nil {
 			if errors.Is(err, storage.ErrKeyNotFound) {
 				httpError(w, http.StatusNotFound, errors.WithStack(err))
@@ -803,7 +803,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 
 		fp := key.QualifiedFingerprint()
 		switch change.(type) {
-		case storage.KeyAdded:
+		case storage.KeyRemoved:
 			result.Deleted = append(result.Deleted, fp)
 		case storage.KeyNotChanged:
 			result.Ignored = append(result.Ignored, fp)

--- a/src/hockeypuck/hkp/handler_test.go
+++ b/src/hockeypuck/hkp/handler_test.go
@@ -127,6 +127,12 @@ func (s *HandlerSuite) SetUpTest(c *gc.C) {
 			return []string{tk.fp}, nil
 		}),
 		mock.FetchRecordsByFp(sliceOfDefaultKeys),
+		// This suite supplies no persistence (no mock.Update), so an upsert of an
+		// already-present key is a dry-run no-op: report it unchanged. Mirrors the
+		// prior behaviour of the generic UpsertKey helper against Alice.
+		mock.Upsert(func(key *openpgp.PrimaryKey) (storage.KeyChange, error) {
+			return storage.KeyNotChanged{ID: key.KeyID, Digest: key.MD5}, nil
+		}),
 		mock.FetchRecordsByMD5(sliceOfDefaultKeys),
 		mock.FetchRecordsByKeyword(func(key string, options ...string) ([]*storage.Record, error) {
 			tk := testKeyDefault

--- a/src/hockeypuck/hkp/sks/recon.go
+++ b/src/hockeypuck/hkp/sks/recon.go
@@ -514,7 +514,7 @@ func (r *Peer) upsertKeys(rcvr *recon.Recover, buf []byte) (*upsertResult, error
 			log.Warnf("could not upsert key %s: %s", key.Fingerprint, err.Error())
 			continue
 		}
-		keyChange, err := storage.UpsertKey(r.storage, key, r.policy)
+		keyChange, err := r.storage.Upsert(key)
 		if err != nil {
 			log.Warnf("could not upsert key %s: %s", key.Fingerprint, err.Error())
 			continue

--- a/src/hockeypuck/hkp/storage/mock/mock.go
+++ b/src/hockeypuck/hkp/storage/mock/mock.go
@@ -55,9 +55,10 @@ type modifiedSinceFunc func(time.Time) ([]string, error)
 type fetchRecordsFunc func([]string, ...string) ([]*storage.Record, error)
 type fetchRecordsSingleFunc func(string, ...string) ([]*storage.Record, error)
 type insertFunc func([]*openpgp.PrimaryKey) (int, int, error)
-type replaceFunc func(*openpgp.PrimaryKey) (string, error)
+type upsertFunc func(*openpgp.PrimaryKey) (storage.KeyChange, error)
+type replaceFunc func(*openpgp.PrimaryKey) (storage.KeyChange, error)
 type updateFunc func(*openpgp.PrimaryKey, string, string) error
-type deleteFunc func(string) (string, error)
+type deleteFunc func(string) (storage.KeyChange, error)
 type renotifyAllFunc func() error
 type pksInitFunc func(string, time.Time) error
 type pksAllFunc func() ([]*pksstorage.Status, error)
@@ -74,6 +75,7 @@ type Storage struct {
 	fetchRecordsByMD5     fetchRecordsFunc
 	fetchRecordsByKeyword fetchRecordsSingleFunc
 	insert                insertFunc
+	upsert                upsertFunc
 	replace               replaceFunc
 	update                updateFunc
 	delete                deleteFunc
@@ -104,6 +106,7 @@ func FetchRecordsByKeyword(f fetchRecordsSingleFunc) Option {
 	return func(m *Storage) { m.fetchRecordsByKeyword = f }
 }
 func Insert(f insertFunc) Option           { return func(m *Storage) { m.insert = f } }
+func Upsert(f upsertFunc) Option           { return func(m *Storage) { m.upsert = f } }
 func Replace(f replaceFunc) Option         { return func(m *Storage) { m.replace = f } }
 func Update(f updateFunc) Option           { return func(m *Storage) { m.update = f } }
 func RenotifyAll(f renotifyAllFunc) Option { return func(m *Storage) { m.renotifyAll = f } }
@@ -171,19 +174,26 @@ func (m *Storage) Insert(keys []*openpgp.PrimaryKey) (int, int, error) {
 	}
 	return 0, 0, nil
 }
-func (m *Storage) Replace(key *openpgp.PrimaryKey) (string, error) {
+func (m *Storage) Upsert(key *openpgp.PrimaryKey) (storage.KeyChange, error) {
+	m.record("Upsert", key)
+	if m.upsert != nil {
+		return m.upsert(key)
+	}
+	return nil, nil
+}
+func (m *Storage) Replace(key *openpgp.PrimaryKey) (storage.KeyChange, error) {
 	m.record("Replace", key)
 	if m.replace != nil {
 		return m.replace(key)
 	}
-	return "", nil
+	return nil, nil
 }
-func (m *Storage) Delete(fp string) (string, error) {
+func (m *Storage) Delete(fp string) (storage.KeyChange, error) {
 	m.record("Delete", fp)
 	if m.delete != nil {
 		return m.delete(fp)
 	}
-	return "", nil
+	return nil, nil
 }
 func (m *Storage) Update(key *openpgp.PrimaryKey, lastID string, lastMD5 string) error {
 	m.record("Update", key)

--- a/src/hockeypuck/hkp/storage/storage.go
+++ b/src/hockeypuck/hkp/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 
 	pksstorage "hockeypuck/hkp/pks/storage"
 	"hockeypuck/openpgp"
@@ -154,15 +153,25 @@ type Updater interface {
 	// match, the update should be retried again later.
 	Update(pubkey *openpgp.PrimaryKey, priorID string, priorMD5 string) error
 
+	// Upsert inserts the given Primary key if it is not already stored, or else
+	// merges it into the stored copy according to the storage's merge policy. It
+	// notifies subscribers and returns the resulting KeyChange (KeyAdded if the
+	// key was newly inserted, KeyReplaced if a merge changed the stored copy, or
+	// KeyNotChanged if the incoming key added nothing).
+	Upsert(pubkey *openpgp.PrimaryKey) (KeyChange, error)
+
 	// Replace unconditionally replaces any existing Primary key with the given
-	// contents, adding it if it did not exist.
-	Replace(pubkey *openpgp.PrimaryKey) (string, error)
+	// contents, adding it if it did not exist. It notifies subscribers and
+	// returns the resulting KeyChange (KeyAdded if nothing was replaced, else
+	// KeyReplaced).
+	Replace(pubkey *openpgp.PrimaryKey) (KeyChange, error)
 }
 
 type Deleter interface {
 	// Delete unconditionally deletes any existing Primary key with the given
-	// fingerprint.
-	Delete(fp string) (string, error)
+	// fingerprint. It notifies subscribers and returns the resulting
+	// KeyRemoved KeyChange.
+	Delete(fp string) (KeyChange, error)
 }
 
 type Notifier interface {
@@ -315,77 +324,6 @@ func Duplicates(err error) []*openpgp.PrimaryKey {
 		return nil
 	}
 	return insertErr.Duplicates
-}
-
-func firstMatch(records []*Record, match string) (*Record, error) {
-	for _, record := range records {
-		if record.Fingerprint == match {
-			return record, nil
-		}
-	}
-	return nil, ErrKeyNotFound
-}
-
-func UpsertKey(storage Storage, pubkey *openpgp.PrimaryKey, policy *openpgp.Policy) (kc KeyChange, err error) {
-	var record *Record
-	records, err := storage.FetchRecordsByFp([]string{pubkey.Fingerprint})
-	if err == nil {
-		// match primary fingerprint -- someone might have reused a subkey somewhere
-		record, err = firstMatch(records, pubkey.Fingerprint)
-	}
-	if IsNotFound(err) {
-		_, _, err = storage.Insert([]*openpgp.PrimaryKey{pubkey})
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return KeyAdded{ID: pubkey.KeyID, Digest: pubkey.MD5}, nil
-	} else if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	// TDOO: do we need to handle other errors?
-	if record.PrimaryKey == nil {
-		// The copy on disk has evaporated; replace it instead
-		log.Debugf("evaporated key fp=%v during upsert; replacing", pubkey.Fingerprint)
-		kc, err := ReplaceKey(storage, pubkey)
-		return kc, err
-	}
-
-	if pubkey.UUID != record.UUID {
-		return nil, errors.Errorf("upsert key %q lookup failed, found mismatch %q", pubkey.UUID, record.UUID)
-	}
-	lastID := record.KeyID
-	lastMD5 := record.MD5
-	err = policy.Merge(record.PrimaryKey, pubkey)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if lastMD5 != record.PrimaryKey.MD5 {
-		err = storage.Update(record.PrimaryKey, lastID, lastMD5)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: record.KeyID, NewDigest: record.PrimaryKey.MD5}, nil
-	}
-	return KeyNotChanged{ID: lastID, Digest: lastMD5}, nil
-}
-
-func ReplaceKey(storage Storage, pubkey *openpgp.PrimaryKey) (KeyChange, error) {
-	lastMD5, err := storage.Replace(pubkey)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if lastMD5 != "" {
-		return KeyReplaced{OldID: pubkey.KeyID, OldDigest: lastMD5, NewID: pubkey.KeyID, NewDigest: pubkey.MD5}, nil
-	}
-	return KeyAdded{ID: pubkey.KeyID, Digest: pubkey.MD5}, nil
-}
-
-func DeleteKey(storage Storage, fp string) (KeyChange, error) {
-	lastMD5, err := storage.Delete(fp)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return KeyRemoved{ID: fp, Digest: lastMD5}, nil
 }
 
 type Reindexer interface {

--- a/src/hockeypuck/pghkp/delete.go
+++ b/src/hockeypuck/pghkp/delete.go
@@ -30,10 +30,10 @@ import (
 // Deleter implementation
 //
 
-func (st *storage) Delete(fp string) (_ string, retErr error) {
+func (st *storage) Delete(fp string) (_ hkpstorage.KeyChange, retErr error) {
 	tx, err := st.Begin()
 	if err != nil {
-		return "", errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 	defer func() {
 		if retErr != nil {
@@ -44,10 +44,11 @@ func (st *storage) Delete(fp string) (_ string, retErr error) {
 	}()
 	md5, err := st.deleteTx(tx, fp)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	st.Notify(hkpstorage.KeyRemoved{ID: fp, Digest: md5})
-	return md5, nil
+	kc := hkpstorage.KeyRemoved{ID: fp, Digest: md5}
+	st.Notify(kc)
+	return kc, nil
 }
 
 // deleteTx does not handle cleanup; the caller MUST defer commit/rollback

--- a/src/hockeypuck/pghkp/reload.go
+++ b/src/hockeypuck/pghkp/reload.go
@@ -131,7 +131,7 @@ func (st *storage) validateRecords(newRecords []*hkpstorage.Record) (newKeys []*
 // Note: it might seem more efficient if getReloadBunch() returned keys rather than records,
 // as this would save a redundant pass over the slice in the happy path, but we wouldn't then
 // be able to call Update+Notify directly in the fallback case - a previous version of this code
-// called upsertKeyOnInsert(), but this added a redundant fetch-preen-merge cycle for each key.
+// called the per-key upsert merge, but this added a redundant fetch-preen-merge cycle for each key.
 func (st *storage) Reload() (totalUpdated, totalDeleted int, _ error) {
 	bookmark := time.Time{}
 	newRecords := make([]*hkpstorage.Record, 0, keysInBunch)

--- a/src/hockeypuck/pghkp/storage_test.go
+++ b/src/hockeypuck/pghkp/storage_test.go
@@ -462,6 +462,39 @@ func (s *S) TestMerge(c *gc.C) {
 	c.Assert(keys[0].UserIDs[0].Signatures, gc.HasLen, 2)
 }
 
+// TestUpsert exercises the three outcomes of the Storage.Upsert path through
+// /pks/add: a brand-new key is added, re-adding it is ignored, and adding a
+// superset of the key is reported as updated.
+func (s *S) TestUpsert(c *gc.C) {
+	var addRes hkp.AddResponse
+
+	// A brand-new key is inserted (KeyAdded).
+	err := json.Unmarshal(s.addKey(c, "alice_unsigned.asc"), &addRes)
+	c.Assert(err, gc.IsNil)
+	c.Assert(addRes.Inserted, gc.HasLen, 1)
+	c.Assert(addRes.Updated, gc.HasLen, 0)
+	c.Assert(addRes.Ignored, gc.HasLen, 0)
+
+	// Re-adding the identical key changes nothing (KeyNotChanged).
+	addRes = hkp.AddResponse{}
+	err = json.Unmarshal(s.addKey(c, "alice_unsigned.asc"), &addRes)
+	c.Assert(err, gc.IsNil)
+	c.Assert(addRes.Inserted, gc.HasLen, 0)
+	c.Assert(addRes.Updated, gc.HasLen, 0)
+	c.Assert(addRes.Ignored, gc.HasLen, 1)
+
+	// Adding a superset (with self-signatures) merges and updates (KeyReplaced).
+	addRes = hkp.AddResponse{}
+	err = json.Unmarshal(s.addKey(c, "alice_signed.asc"), &addRes)
+	c.Assert(err, gc.IsNil)
+	c.Assert(addRes.Inserted, gc.HasLen, 0)
+	c.Assert(addRes.Updated, gc.HasLen, 1)
+	c.Assert(addRes.Ignored, gc.HasLen, 0)
+
+	// The merge should have collapsed into a single stored key.
+	c.Assert(s.queryAllKeys(c), gc.HasLen, 1)
+}
+
 func (s *S) TestPolicyURI(c *gc.C) {
 	log.Infof("starting TestPolicyURI")
 	doc := s.addKey(c, "gentoo-l2-infra.asc")

--- a/src/hockeypuck/pghkp/update.go
+++ b/src/hockeypuck/pghkp/update.go
@@ -36,7 +36,16 @@ import (
 // Updater implementation
 //
 
-func (st *storage) upsertKeyOnInsert(pubkey *openpgp.PrimaryKey) (kc hkpstorage.KeyChange, err error) {
+// mergeStoredKey merges the incoming key into an already-stored copy with the
+// same fingerprint. It is only called once an insert attempt has found that the
+// key already exists. Every storage-mutating path notifies subscribers itself
+// (st.Delete and st.Update notify internally; the evaporated branch notifies
+// explicitly), so callers MUST NOT re-notify the returned change. The
+// KeyNotChanged path mutates nothing and so emits no notification.
+//
+// errTargetMissing is returned verbatim if the stored copy changed underneath
+// us, so that the Upsert back-off loop can detect and retry it.
+func (st *storage) mergeStoredKey(pubkey *openpgp.PrimaryKey) (kc hkpstorage.KeyChange, err error) {
 	var lastRecord *hkpstorage.Record
 	// Don't use AutoPreen, as this can cause double-updates. We explicitly call preen() below.
 	lastRecords, err := st.FetchRecordsByFp([]string{pubkey.Fingerprint})
@@ -63,37 +72,83 @@ func (st *storage) upsertKeyOnInsert(pubkey *openpgp.PrimaryKey) (kc hkpstorage.
 	err = st.preen(lastRecord)
 	if err == openpgp.ErrKeyEvaporated {
 		// Key on disk is invalid. Delete and insert the incoming key directly.
-		_, err := st.Delete(lastRecord.Fingerprint)
-		if err != nil {
-			log.Errorf("could not delete fp=%s: %v", lastRecord.Fingerprint, err)
+		// A delete failure is only logged, not fatal: we still try to insert, and
+		// the needUpsert check below catches the case where the stale row survives.
+		_, delErr := st.Delete(lastRecord.Fingerprint)
+		if delErr != nil {
+			log.Errorf("could not delete fp=%s: %v", lastRecord.Fingerprint, delErr)
 		}
 		needUpsert, err := st.insertKey(pubkey)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 		if needUpsert {
-			return nil, errors.Errorf("evaporated key needs Upsert; this should be impossible!")
+			// The row still exists after the delete+insert, so we could neither
+			// merge (preen said the key had evaporated) nor replace it. This most
+			// likely means the delete above failed, or a peer concurrently
+			// re-inserted the fingerprint.
+			return nil, errors.Errorf("evaporated key fp=%v still present after delete+insert (delete error: %v)",
+				lastRecord.Fingerprint, delErr)
 		}
-		return hkpstorage.KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: lastRecord.KeyID, NewDigest: lastRecord.MD5}, nil
+		// st.Delete above notified the removal, but insertKey does not notify,
+		// so announce the replacement with the incoming key explicitly.
+		kc := hkpstorage.KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: pubkey.KeyID, NewDigest: pubkey.MD5}
+		st.Notify(kc)
+		return kc, nil
 	} else if err != nil && err != hkpstorage.ErrDigestMismatch {
 		return nil, errors.WithStack(err)
 	}
 
+	// Merge the incoming key into the stored copy. If the merge changes the key
+	// material, st.Update persists it and notifies the KeyReplaced itself.
 	err = st.policy.Merge(lastRecord.PrimaryKey, pubkey)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if lastMD5 != lastRecord.MD5 {
-		err = st.Update(lastRecord.PrimaryKey, lastID, lastMD5)
-		if err == errTargetMissing {
-			// propagate verbatim so it can be handled
-			return nil, err
-		} else if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return hkpstorage.KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: lastRecord.KeyID, NewDigest: lastRecord.MD5}, nil
+	if lastMD5 == lastRecord.PrimaryKey.MD5 {
+		return hkpstorage.KeyNotChanged{ID: lastID, Digest: lastMD5}, nil
 	}
-	return hkpstorage.KeyNotChanged{ID: lastID, Digest: lastMD5}, nil
+	err = st.Update(lastRecord.PrimaryKey, lastID, lastMD5)
+	if err != nil {
+		// errTargetMissing is propagated verbatim for the back-off loop.
+		return nil, err
+	}
+	return hkpstorage.KeyReplaced{OldID: lastID, OldDigest: lastMD5, NewID: lastRecord.KeyID, NewDigest: lastRecord.PrimaryKey.MD5}, nil
+}
+
+// Upsert inserts pubkey if it is not already stored, otherwise merges it into
+// the stored copy according to the storage's merge policy. It notifies
+// subscribers and returns the resulting KeyChange.
+func (st *storage) Upsert(pubkey *openpgp.PrimaryKey) (hkpstorage.KeyChange, error) {
+	needUpsert, err := st.insertKey(pubkey)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !needUpsert {
+		// insertKey does not notify, so announce the new key here.
+		kc := hkpstorage.KeyAdded{ID: pubkey.KeyID, Digest: pubkey.MD5}
+		st.Notify(kc)
+		return kc, nil
+	}
+
+	// The key already exists; merge the incoming key into it. errTargetMissing
+	// is thrown if the stored copy changes underneath us (e.g. concurrent
+	// updates); back off a few times before giving up.
+	var kc hkpstorage.KeyChange
+	for i := 0; i < 3; i++ {
+		kc, err = st.mergeStoredKey(pubkey)
+		if err != errTargetMissing {
+			break
+		}
+		log.Infof("key fp(%v) is slippery; backing off", pubkey.Fingerprint)
+	}
+	if err == errTargetMissing {
+		return nil, errors.Errorf("key fp(%v) was changing while we were updating it", pubkey.Fingerprint)
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return kc, nil
 }
 
 func (st *storage) insertKeyTx(tx *sql.Tx, key *openpgp.PrimaryKey) (needUpsert bool, retErr error) {
@@ -211,44 +266,20 @@ func (st *storage) Insert(keys []*openpgp.PrimaryKey) (u, n int, retErr error) {
 				return u, n, result
 			}
 
-			if needUpsert, err := st.insertKey(key); err != nil {
+			kc, err := st.Upsert(key)
+			if err != nil {
 				result.Errors = append(result.Errors, err)
 				continue
-			} else if needUpsert {
-				var kc hkpstorage.KeyChange
-				// errTargetMissing is thrown if Update() can't find the key it was told to modify.
-				// This can happen in case of concurrent updates to the same key. Back off a few times.
-				for i := 0; i < 3; i++ {
-					kc, err = st.upsertKeyOnInsert(key)
-					if err != errTargetMissing {
-						break
-					}
-					log.Infof("key fp(%v) is slippery; backing off", key.Fingerprint)
-				}
-				if err == errTargetMissing {
-					result.Errors = append(result.Errors,
-						errors.Errorf("key fp(%v) was changing while we were updating it", key.Fingerprint))
-				} else if err != nil {
-					result.Errors = append(result.Errors, err)
-					continue
-				} else {
-					switch kc.(type) {
-					case hkpstorage.KeyReplaced:
-						// FIXME: Listener in hockeypuck-load not really prepared for
-						// hkpstorage.KeyReplaced notifications but stats are updated...
-						st.Notify(kc)
-						u++
-					case hkpstorage.KeyNotChanged:
-						result.Duplicates = append(result.Duplicates, key)
-					}
-				}
-				continue
-			} else {
-				st.Notify(hkpstorage.KeyAdded{
-					ID:     key.KeyID,
-					Digest: key.MD5,
-				})
+			}
+			switch kc.(type) {
+			case hkpstorage.KeyAdded:
 				n++
+			case hkpstorage.KeyReplaced:
+				// FIXME: Listener in hockeypuck-load not really prepared for
+				// hkpstorage.KeyReplaced notifications but stats are updated...
+				u++
+			case hkpstorage.KeyNotChanged:
+				result.Duplicates = append(result.Duplicates, key)
 			}
 		}
 	}
@@ -259,10 +290,10 @@ func (st *storage) Insert(keys []*openpgp.PrimaryKey) (u, n int, retErr error) {
 	return u, n, nil
 }
 
-func (st *storage) Replace(key *openpgp.PrimaryKey) (_ string, retErr error) {
+func (st *storage) Replace(key *openpgp.PrimaryKey) (_ hkpstorage.KeyChange, retErr error) {
 	tx, err := st.Begin()
 	if err != nil {
-		return "", errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 	defer func() {
 		if retErr != nil {
@@ -271,22 +302,32 @@ func (st *storage) Replace(key *openpgp.PrimaryKey) (_ string, retErr error) {
 			retErr = tx.Commit()
 		}
 	}()
+	// A not-found here just means there was nothing to replace; Replace is
+	// documented to add the key in that case, so carry on with an empty prior
+	// md5 (which yields a KeyAdded change below).
 	md5, err := st.deleteTx(tx, key.Fingerprint)
-	if err != nil {
-		return "", errors.WithStack(err)
+	if err != nil && !errors.Is(err, hkpstorage.ErrKeyNotFound) {
+		return nil, errors.WithStack(err)
 	}
 	_, err = st.insertKeyTx(tx, key)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
 
-	st.Notify(hkpstorage.KeyReplaced{
-		OldID:     key.KeyID,
-		OldDigest: md5,
-		NewID:     key.KeyID,
-		NewDigest: key.MD5,
-	})
-	return md5, nil
+	var kc hkpstorage.KeyChange
+	if md5 == "" {
+		// Nothing was replaced; the key was newly added.
+		kc = hkpstorage.KeyAdded{ID: key.KeyID, Digest: key.MD5}
+	} else {
+		kc = hkpstorage.KeyReplaced{
+			OldID:     key.KeyID,
+			OldDigest: md5,
+			NewID:     key.KeyID,
+			NewDigest: key.MD5,
+		}
+	}
+	st.Notify(kc)
+	return kc, nil
 }
 
 func (st *storage) Update(key *openpgp.PrimaryKey, lastID string, lastMD5 string) (retErr error) {


### PR DESCRIPTION
… their changes (#455)

Backport of the #455 storage write-path consolidation to branch-2.3. Same logical change as on master, re-applied to 2.3's slightly older files (older Queryer interface, AddResponse/DeleteResponse handler types).

- Updater.Replace and Deleter.Delete now return (KeyChange, error) and Notify internally; add Updater.Upsert(pubkey) (KeyChange, error).
- Remove the free helpers ReplaceKey/DeleteKey/UpsertKey; callers use the Storage methods directly (Upsert drops its policy argument, as the storage already holds the same policy instance).
- pghkp: Upsert is the extracted per-key body of Insert; Insert's non-bulk loop calls Upsert. Rename the merge helper upsertKeyOnInsert -> mergeStoredKey with sole notification ownership. Replace adds the key when none existed (not-found from deleteTx is "nothing replaced").

Fixes carried over from master:
- Merge change-detection compared against Record.MD5 (never touched by policy.Merge) instead of PrimaryKey.MD5, so merges on Insert were silently dropped; now fixed, which also removes the double KeyReplaced notification that fix would have exposed.
- The Delete handler switch matched KeyAdded, but Delete returns KeyRemoved, so successful deletes were never reported.

This consolidates the merge/update "did it change?" logic into the single mergeStoredKey site, which is where #456 (explicit changed flag from Policy.Merge/ValidSelfSigned) can then be solved in one place.

mock gains Upsert; adds pghkp TestUpsert (KeyAdded/KeyNotChanged/ KeyReplaced). Verified with go build/vet/test and the pghkp Postgres integration suite (24 checks) against PostgreSQL 15.